### PR TITLE
Add logic for the last processed maintenance id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/
 *.test
 *.txt
 .env
+.vscode

--- a/internal/api/errors/incident.go
+++ b/internal/api/errors/incident.go
@@ -24,3 +24,5 @@ var ErrIncidentPatchOpenedStartDate = errors.New("can not change start date for 
 var ErrIncidentPatchOpenedEndDateMissing = errors.New("wrong end date with resolved status")
 var ErrIncidentPatchImpactStatusWrong = errors.New("wrong status for changing impact")
 var ErrIncidentPatchImpactToMaintenanceForbidden = errors.New("can not change impact to maintenance")
+
+var ErrMaintenanceEndDateEmpty = errors.New("maintenance end_date is empty")

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stackmon/otc-status-dashboard/internal/api/common"
 	apiErrors "github.com/stackmon/otc-status-dashboard/internal/api/errors"
 	"github.com/stackmon/otc-status-dashboard/internal/db"
-	"github.com/stackmon/otc-status-dashboard/internal/statuses"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 const (
@@ -42,9 +42,9 @@ type IncidentData struct {
 
 // IncidentStatus is a db table representation.
 type IncidentStatus struct {
-	Status    statuses.EventStatus `json:"status"`
-	Text      string               `json:"text"`
-	Timestamp SD2Time              `json:"timestamp"`
+	Status    event.Status `json:"status"`
+	Text      string       `json:"text"`
+	Timestamp SD2Time      `json:"timestamp"`
 }
 
 type Incident struct {

--- a/internal/api/v2/validation.go
+++ b/internal/api/v2/validation.go
@@ -7,25 +7,25 @@ import (
 
 	apiErrors "github.com/stackmon/otc-status-dashboard/internal/api/errors"
 	"github.com/stackmon/otc-status-dashboard/internal/db"
-	"github.com/stackmon/otc-status-dashboard/internal/statuses"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 // IsValidIncidentFilterStatus checks if the status is valid for maintenance or incidents.
-func IsValidIncidentFilterStatus(status statuses.EventStatus) bool {
-	if statuses.IsMaintenanceStatus(status) {
+func IsValidIncidentFilterStatus(status event.Status) bool {
+	if event.IsMaintenanceStatus(status) {
 		return true
 	}
-	if statuses.IsIncidentOpenStatus(status) {
+	if event.IsIncidentOpenStatus(status) {
 		return true
 	}
-	if statuses.IsIncidentClosedStatus(status) {
+	if event.IsIncidentClosedStatus(status) {
 		return true
 	}
 	return false
 }
 
 // validateAndSetStatus validates the query status and sets it on db.IncidentsParams.
-func validateAndSetStatus(queryStatus *statuses.EventStatus, params *db.IncidentsParams) error {
+func validateAndSetStatus(queryStatus *event.Status, params *db.IncidentsParams) error {
 	if queryStatus != nil {
 		if !IsValidIncidentFilterStatus(*queryStatus) {
 			return apiErrors.ErrIncidentFQueryInvalidFormat

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,12 +11,7 @@ import (
 	"moul.io/zapgorm2"
 
 	"github.com/stackmon/otc-status-dashboard/internal/conf"
-	"github.com/stackmon/otc-status-dashboard/internal/statuses"
-)
-
-const (
-	statusSYSTEM      = "SYSTEM"
-	eventTypeIncident = "incident"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 type DB struct {
@@ -53,7 +48,7 @@ func (db *DB) Close() error {
 
 type IncidentsParams struct {
 	Type         *string
-	Status       *statuses.EventStatus
+	Status       *event.Status
 	StartDate    *time.Time
 	EndDate      *time.Time
 	Impact       *int
@@ -398,7 +393,7 @@ func (db *DB) MoveComponentFromOldToAnotherIncident(
 	text := fmt.Sprintf("%s moved from %s", comp.PrintAttrs(), incOld.Link())
 	incNew.Statuses = append(incNew.Statuses, IncidentStatus{
 		IncidentID: incNew.ID,
-		Status:     statuses.OutDatedSystem,
+		Status:     event.OutDatedSystem,
 		Text:       text,
 		Timestamp:  timeNow,
 	})
@@ -410,7 +405,7 @@ func (db *DB) MoveComponentFromOldToAnotherIncident(
 
 	incOld.Statuses = append(incOld.Statuses, IncidentStatus{
 		IncidentID: incOld.ID,
-		Status:     statuses.OutDatedSystem,
+		Status:     event.OutDatedSystem,
 		Text:       text,
 		Timestamp:  timeNow,
 	})
@@ -458,7 +453,7 @@ func (db *DB) ExtractComponentsToNewIncident(
 		Impact:     &impact,
 		Statuses:   []IncidentStatus{},
 		System:     false,
-		Type:       eventTypeIncident,
+		Type:       event.TypeIncident,
 		Components: comp,
 	}
 
@@ -471,7 +466,7 @@ func (db *DB) ExtractComponentsToNewIncident(
 		incText := fmt.Sprintf("%s moved from %s", c.PrintAttrs(), incOld.Link())
 		inc.Statuses = append(inc.Statuses, IncidentStatus{
 			IncidentID: id,
-			Status:     statuses.OutDatedSystem,
+			Status:     event.OutDatedSystem,
 			Text:       incText,
 			Timestamp:  timeNow,
 		})
@@ -491,7 +486,7 @@ func (db *DB) ExtractComponentsToNewIncident(
 		incText := fmt.Sprintf("%s moved to %s", c.PrintAttrs(), inc.Link())
 		incOld.Statuses = append(incOld.Statuses, IncidentStatus{
 			IncidentID: inc.ID,
-			Status:     statuses.OutDatedSystem,
+			Status:     event.OutDatedSystem,
 			Text:       incText,
 			Timestamp:  timeNow,
 		})
@@ -510,7 +505,7 @@ func (db *DB) IncreaseIncidentImpact(inc *Incident, impact int) (*Incident, erro
 	text := fmt.Sprintf("impact changed from %d to %d", *inc.Impact, impact)
 	inc.Statuses = append(inc.Statuses, IncidentStatus{
 		IncidentID: inc.ID,
-		Status:     statuses.OutDatedSystem,
+		Status:     event.OutDatedSystem,
 		Text:       text,
 		Timestamp:  timeNow,
 	})

--- a/internal/db/maintenances.go
+++ b/internal/db/maintenances.go
@@ -14,7 +14,7 @@ func (db *DB) GetMaintenances(after uint) ([]*Incident, error) {
 	r.Where("incident.impact = 0")
 
 	if after > 0 {
-		r.Where("incident.id > ?", after)
+		r.Where("incident.id >= ?", after)
 	}
 
 	r = r.Order("incident.id DESC")

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stackmon/otc-status-dashboard/internal/statuses"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 type Component struct {
@@ -67,11 +67,11 @@ func (in *Incident) Link() string {
 
 // IncidentStatus is a db table representation.
 type IncidentStatus struct {
-	ID         uint                 `json:"-" gorm:"primaryKey;autoIncrement:true;"`
-	IncidentID uint                 `json:"-"`
-	Status     statuses.EventStatus `json:"status"`
-	Text       string               `json:"text"`
-	Timestamp  time.Time            `json:"timestamp"`
+	ID         uint         `json:"-" gorm:"primaryKey;autoIncrement:true;"`
+	IncidentID uint         `json:"-"`
+	Status     event.Status `json:"status"`
+	Text       string       `json:"text"`
+	Timestamp  time.Time    `json:"timestamp"`
 }
 
 func (is *IncidentStatus) TableName() string {

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -1,25 +1,31 @@
 //nolint:exhaustive
-package statuses
+package event
 
 import (
 	"fmt"
 	"time"
 )
 
-type EventStatus string
-
-const OutDatedSystem EventStatus = "SYSTEM"
-
 const (
-	MaintenancePlanned    EventStatus = "planned"
-	MaintenanceInProgress EventStatus = "in progress"
-	// MaintenanceModified is placed if the time window was changed.
-	MaintenanceModified  EventStatus = "modified"
-	MaintenanceCompleted EventStatus = "completed"
-	MaintenanceCancelled EventStatus = "cancelled"
+	TypeMaintenance = "maintenance"
+	TypeIncident    = "incident"
+	TypeInformation = "info"
 )
 
-func IsMaintenanceStatus(status EventStatus) bool {
+type Status string
+
+const OutDatedSystem Status = "SYSTEM"
+
+const (
+	MaintenancePlanned    Status = "planned"
+	MaintenanceInProgress Status = "in progress"
+	// MaintenanceModified is placed if the time window was changed.
+	MaintenanceModified  Status = "modified"
+	MaintenanceCompleted Status = "completed"
+	MaintenanceCancelled Status = "cancelled"
+)
+
+func IsMaintenanceStatus(status Status) bool {
 	switch status {
 	case MaintenancePlanned, MaintenanceInProgress, MaintenanceModified,
 		MaintenanceCompleted, MaintenanceCancelled:
@@ -31,15 +37,15 @@ func IsMaintenanceStatus(status EventStatus) bool {
 
 // Incident actions for opened incidents.
 const (
-	IncidentDetected      EventStatus = "detected" // not implemented yet
-	IncidentAnalysing     EventStatus = "analysing"
-	IncidentFixing        EventStatus = "fixing"
-	IncidentImpactChanged EventStatus = "impact changed"
-	IncidentObserving     EventStatus = "observing"
-	IncidentResolved      EventStatus = "resolved"
+	IncidentDetected      Status = "detected" // not implemented yet
+	IncidentAnalysing     Status = "analysing"
+	IncidentFixing        Status = "fixing"
+	IncidentImpactChanged Status = "impact changed"
+	IncidentObserving     Status = "observing"
+	IncidentResolved      Status = "resolved"
 )
 
-func IsIncidentOpenStatus(status EventStatus) bool {
+func IsIncidentOpenStatus(status Status) bool {
 	switch status {
 	case IncidentDetected, IncidentAnalysing, IncidentFixing,
 		IncidentImpactChanged, IncidentObserving, IncidentResolved:
@@ -51,12 +57,12 @@ func IsIncidentOpenStatus(status EventStatus) bool {
 
 // These statuses are using only for closed incidents.
 const (
-	IncidentReopened EventStatus = "reopened"
+	IncidentReopened Status = "reopened"
 	// IncidentChanged indicates if the end date was changed for closed incident.
-	IncidentChanged EventStatus = "changed"
+	IncidentChanged Status = "changed"
 )
 
-func IsIncidentClosedStatus(status EventStatus) bool {
+func IsIncidentClosedStatus(status Status) bool {
 	switch status {
 	case IncidentReopened, IncidentChanged:
 		return true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -607,6 +607,7 @@ components:
         - impact
         - components
         - start_date
+        - type
       properties:
         title:
           type: string
@@ -632,6 +633,12 @@ components:
         system:
           type: boolean
           example: false
+        type:
+          type: string
+          enum:
+            - "incident"
+            - "maintenance"
+          example: "incident"
     IncidentPostResponse:
       type: object
       properties:

--- a/tests/v1_test.go
+++ b/tests/v1_test.go
@@ -15,7 +15,7 @@ import (
 
 	v1 "github.com/stackmon/otc-status-dashboard/internal/api/v1"
 	"github.com/stackmon/otc-status-dashboard/internal/db"
-	"github.com/stackmon/otc-status-dashboard/internal/statuses"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 func TestV1GetIncidentsHandler(t *testing.T) {
@@ -125,7 +125,7 @@ func TestV1PostComponentsStatusHandler(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, componentCreateData.Impact, *newInc.Impact)
 	assert.Len(t, newInc.Updates, 1)
-	assert.Equal(t, statuses.OutDatedSystem, newInc.Updates[0].Status)
+	assert.Equal(t, event.OutDatedSystem, newInc.Updates[0].Status)
 	assert.Equal(t, "impact changed from 1 to 2", newInc.Updates[0].Text)
 	assert.NotNil(t, newInc.Updates[0].Timestamp)
 
@@ -148,7 +148,7 @@ func TestV1PostComponentsStatusHandler(t *testing.T) {
 	for _, u := range newInc.Updates {
 		if strings.HasPrefix(u.Text, "Cloud Container Engine") {
 			assert.Equal(t, "Cloud Container Engine (Container, EU-NL, cce) added", u.Text)
-			assert.Equal(t, statuses.OutDatedSystem, u.Status)
+			assert.Equal(t, event.OutDatedSystem, u.Status)
 		}
 	}
 
@@ -308,7 +308,7 @@ func checkIncidentsDataAfterMoveV1(t *testing.T, r *gin.Engine) {
 			assert.Nil(t, inc.EndDate)
 			assert.Equal(t, 3, *inc.Impact)
 			assert.Len(t, inc.Updates, 1)
-			assert.Equal(t, statuses.OutDatedSystem, inc.Updates[0].Status)
+			assert.Equal(t, event.OutDatedSystem, inc.Updates[0].Status)
 			assert.Equal(t, "Distributed Cache Service (Database, EU-NL, dcs) moved from <a href='/incidents/2'>Test incident for dcs</a>", inc.Updates[0].Text)
 		case 2:
 			assert.Nil(t, inc.EndDate)
@@ -359,8 +359,8 @@ func checkIncidentsDataAfterMoveAndClosedIncidentV1(t *testing.T, r *gin.Engine)
 			assert.Nil(t, inc.EndDate)
 			assert.Equal(t, 3, *inc.Impact)
 			assert.Len(t, inc.Updates, 2)
-			assert.Equal(t, statuses.OutDatedSystem, inc.Updates[0].Status)
-			assert.Equal(t, statuses.OutDatedSystem, inc.Updates[1].Status)
+			assert.Equal(t, event.OutDatedSystem, inc.Updates[0].Status)
+			assert.Equal(t, event.OutDatedSystem, inc.Updates[1].Status)
 			assert.Equal(t, "Distributed Cache Service (Database, EU-NL, dcs) moved from <a href='/incidents/2'>Test incident for dcs</a>", inc.Updates[0].Text)
 			assert.Equal(t, "Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/2'>Test incident for dcs</a>", inc.Updates[1].Text)
 		case 2:

--- a/tests/v2_test.go
+++ b/tests/v2_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v2 "github.com/stackmon/otc-status-dashboard/internal/api/v2"
-	"github.com/stackmon/otc-status-dashboard/internal/statuses"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 const (
@@ -257,8 +257,8 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Len(t, oldIncident.Components, 1)
 	assert.NotNil(t, oldIncident.Updates)
 	assert.Len(t, oldIncident.Updates, 2)
-	assert.Equal(t, statuses.OutDatedSystem, oldIncident.Updates[0].Status)
-	assert.Equal(t, statuses.OutDatedSystem, oldIncident.Updates[1].Status)
+	assert.Equal(t, event.OutDatedSystem, oldIncident.Updates[0].Status)
+	assert.Equal(t, event.OutDatedSystem, oldIncident.Updates[1].Status)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved to <a href='/incidents/%d'>Test incident for dcs</a>", result.Result[0].IncidentID), oldIncident.Updates[0].Text)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test incident for dcs</a>, Incident closed by system", result.Result[0].IncidentID), oldIncident.Updates[1].Text)
 
@@ -267,8 +267,8 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Len(t, incidentN3.Components, 2)
 	assert.NotNil(t, incidentN3.Updates)
 	assert.Len(t, incidentN3.Updates, 2)
-	assert.Equal(t, statuses.OutDatedSystem, incidentN3.Updates[0].Status)
-	assert.Equal(t, statuses.OutDatedSystem, incidentN3.Updates[1].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[0].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident for dcs</a>", result.Result[0].IncidentID-1), incidentN3.Updates[0].Text)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident for dcs</a>", result.Result[0].IncidentID-1), incidentN3.Updates[1].Text)
 
@@ -295,18 +295,18 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Equal(t, impact, *maintenanceIncident.Impact)
 	assert.Equal(t, system, *maintenanceIncident.System)
 	assert.Equal(t, incidentCreateData.Description, maintenanceIncident.Updates[0].Text)
-	assert.Equal(t, statuses.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
+	assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
 	require.NotNil(t, maintenanceIncident.Type)
 	assert.Equal(t, "maintenance", maintenanceIncident.Type)
-	assert.Equal(t, statuses.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
+	assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
 
 	incidentN3 = v2GetIncident(t, r, result.Result[0].IncidentID-1)
 	assert.Nil(t, incidentN3.EndDate)
 	assert.Len(t, incidentN3.Components, 2)
 	assert.NotNil(t, incidentN3.Updates)
 	assert.Len(t, incidentN3.Updates, 2)
-	assert.Equal(t, statuses.OutDatedSystem, incidentN3.Updates[0].Status)
-	assert.Equal(t, statuses.OutDatedSystem, incidentN3.Updates[1].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[0].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident for dcs</a>", incidentN3.ID-1), incidentN3.Updates[0].Text)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident for dcs</a>", incidentN3.ID-1), incidentN3.Updates[1].Text)
 	require.NotNil(t, incidentN3.Type)
@@ -482,13 +482,13 @@ func TestV2PatchIncidentHandler(t *testing.T) {
 	t.Logf("patching incident impact, from %d to %d", impact, newImpact)
 
 	pData.Impact = &newImpact
-	pData.Status = statuses.IncidentImpactChanged
+	pData.Status = event.IncidentImpactChanged
 
 	inc = internalPatch(incID, &pData)
 	assert.Equal(t, newImpact, *inc.Impact)
 
 	t.Logf("close incident")
-	pData.Status = statuses.IncidentResolved
+	pData.Status = event.IncidentResolved
 	updateDate := time.Now().UTC()
 	pData.UpdateDate = updateDate
 
@@ -500,7 +500,7 @@ func TestV2PatchIncidentHandler(t *testing.T) {
 	startDate = time.Now().AddDate(0, 0, -1).UTC()
 	endDate := time.Now().UTC()
 
-	pData.Status = statuses.IncidentChanged
+	pData.Status = event.IncidentChanged
 	pData.StartDate = &startDate
 	pData.EndDate = &endDate
 
@@ -511,7 +511,7 @@ func TestV2PatchIncidentHandler(t *testing.T) {
 
 	t.Logf("reopen closed incident")
 
-	pData.Status = statuses.IncidentReopened
+	pData.Status = event.IncidentReopened
 	pData.StartDate = nil
 	pData.EndDate = nil
 	inc = internalPatch(incID, &pData)
@@ -519,7 +519,7 @@ func TestV2PatchIncidentHandler(t *testing.T) {
 
 	t.Logf("final close the test incident")
 
-	pData.Status = statuses.IncidentResolved
+	pData.Status = event.IncidentResolved
 	inc = internalPatch(incID, &pData)
 	assert.NotNil(t, inc.EndDate)
 }
@@ -1055,5 +1055,5 @@ func TestV2PostMaintenanceHandler(t *testing.T) {
 	assert.Equal(t, impact, *incident.Impact)
 	assert.Equal(t, system, *incident.System)
 	assert.NotNil(t, incident.Updates)
-	assert.Equal(t, statuses.MaintenancePlanned, incident.Updates[0].Status)
+	assert.Equal(t, event.MaintenancePlanned, incident.Updates[0].Status)
 }


### PR DESCRIPTION
This PR add ability to set up the last checked maintenance ID, for improving db records extraction. 

Refactor statuses to event, for more logic naming.