### PR TITLE
add info events to the checker

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1,14 +1,13 @@
 package checker
 
 import (
-	"slices"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/stackmon/otc-status-dashboard/internal/conf"
 	"github.com/stackmon/otc-status-dashboard/internal/db"
-	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 const defaultPeriod = time.Minute * 5
@@ -16,8 +15,9 @@ const defaultPeriod = time.Minute * 5
 type Checker struct {
 	db  *db.DB
 	log *zap.Logger
-	// lastID is the earliest planned or in progress maintenance ID.
-	lastID uint
+	// lastIDs are the earliest planned or in progress maintenance/info events ID.
+	lastMntID  uint
+	lastInfoID uint
 }
 
 func New(c *conf.Config, log *zap.Logger) (*Checker, error) {
@@ -28,164 +28,28 @@ func New(c *conf.Config, log *zap.Logger) (*Checker, error) {
 	return &Checker{db: dbNew, log: log}, nil
 }
 
-type StatusHistory struct {
-	hasPlanned    bool
-	hasInProgress bool
-	hasCompleted  bool
-	hasCancelled  bool
-}
+func (ch *Checker) Check() {
+	var wg sync.WaitGroup
 
-func (ch *Checker) Check() error {
-	ch.log.Info("check maintenances statuses")
-	if ch.lastID == 0 {
-		ch.log.Info("no last completed maintenance, starting from the beginning")
-	}
-
-	maintenances, err := ch.db.GetMaintenances(ch.lastID)
-	if err != nil {
-		return err
-	}
-
-	var actualMN []uint
-	for _, mn := range maintenances {
-		sHistory := calculateStatusHistory(mn)
-		actualStatus := calculateCurrentStatus(sHistory, mn)
-
-		// collect statuses for correction
-		missedStatuses := make([]db.IncidentStatus, 0)
-
-		switch actualStatus { //nolint:exhaustive
-		case event.MaintenancePlanned:
-			ch.fixPlannedStatus(sHistory, mn)
-			actualMN = append(actualMN, mn.ID)
-		case event.MaintenanceInProgress:
-			ch.fixInProgressStatus(sHistory, mn)
-			actualMN = append(actualMN, mn.ID)
-		case event.MaintenanceCompleted:
-			ch.fixCompletedStatus(sHistory, mn)
-		case event.MaintenanceCancelled:
-			ch.fixCancelledStatus(sHistory, mn)
-		}
-
-		mn.Statuses = append(mn.Statuses, missedStatuses...)
-		err = ch.db.ModifyIncident(mn)
+	wg.Add(1)
+	go func() {
+		err := ch.CheckMaintenance()
 		if err != nil {
-			return err
+			ch.log.Error("error to check maintenances", zap.Error(err))
 		}
-	}
+		wg.Done()
+	}()
 
-	if len(actualMN) == 0 {
-		for _, mn := range maintenances {
-			if mn.ID > ch.lastID {
-				ch.lastID = mn.ID
-			}
+	wg.Add(1)
+	go func() {
+		err := ch.CheckInfoEvents()
+		if err != nil {
+			ch.log.Error("error to check info events", zap.Error(err))
 		}
-		ch.log.Debug("there are no actual maintenances, set the last ID to the last one", zap.Uint("lastID", ch.lastID))
-	} else {
-		ch.lastID = slices.Min(actualMN)
-		ch.log.Debug("set the last ID to the earliest planned or in progress maintenance", zap.Uint("lastID", ch.lastID))
-	}
+		wg.Done()
+	}()
 
-	ch.log.Info("finished checking maintenances")
-
-	return nil
-}
-
-func calculateStatusHistory(mn *db.Incident) *StatusHistory {
-	sHistory := &StatusHistory{}
-	for _, st := range mn.Statuses {
-		if st.Status == event.MaintenancePlanned {
-			sHistory.hasPlanned = true
-		}
-		if st.Status == event.MaintenanceInProgress {
-			sHistory.hasInProgress = true
-		}
-		if st.Status == event.MaintenanceCompleted {
-			sHistory.hasCompleted = true
-		}
-		if st.Status == event.MaintenanceCancelled {
-			sHistory.hasCancelled = true
-		}
-	}
-
-	return sHistory
-}
-func calculateCurrentStatus(sHistory *StatusHistory, mn *db.Incident) event.Status {
-	if sHistory.hasCancelled {
-		return event.MaintenanceCancelled
-	}
-
-	now := time.Now().UTC()
-
-	// calculate the mn current status
-	if mn.StartDate.After(now) {
-		return event.MaintenancePlanned
-	}
-
-	if mn.StartDate.Before(now) && mn.EndDate.After(now) {
-		return event.MaintenanceInProgress
-	}
-
-	return event.MaintenanceCompleted
-}
-
-func (ch *Checker) fixPlannedStatus(sHistory *StatusHistory, mn *db.Incident) {
-	if sHistory.hasPlanned {
-		ch.log.Debug("the maintenance is already has planned status", zap.Uint("maintenance_id", mn.ID))
-		return
-	}
-
-	mn.Statuses = append(mn.Statuses, db.IncidentStatus{
-		IncidentID: mn.ID,
-		Status:     event.MaintenancePlanned,
-		Text:       event.MaintenancePlannedStatusText(),
-		Timestamp:  *mn.StartDate,
-	})
-
-	sHistory.hasPlanned = true
-	ch.log.Info("the status 'planned' was added", zap.Uint("maintenance_id", mn.ID))
-}
-
-// fixCancelledStatus checks if the maintenance has planned and in progress statuses.
-func (ch *Checker) fixInProgressStatus(sHistory *StatusHistory, mn *db.Incident) {
-	ch.fixPlannedStatus(sHistory, mn)
-
-	if sHistory.hasInProgress {
-		ch.log.Debug("the maintenance is already has status 'in_progress'", zap.Uint("maintenance_id", mn.ID))
-		return
-	}
-
-	mn.Statuses = append(mn.Statuses, db.IncidentStatus{
-		IncidentID: mn.ID,
-		Status:     event.MaintenanceInProgress,
-		Text:       "The maintenance is started.",
-		Timestamp:  *mn.StartDate,
-	})
-
-	sHistory.hasInProgress = true
-	ch.log.Info("the status 'in_progress' was added", zap.Uint("maintenance_id", mn.ID))
-}
-
-func (ch *Checker) fixCompletedStatus(sHistory *StatusHistory, mn *db.Incident) {
-	ch.fixPlannedStatus(sHistory, mn)
-	ch.fixInProgressStatus(sHistory, mn)
-
-	if sHistory.hasCompleted {
-		ch.log.Debug("the maintenance is already has status 'completed'", zap.Uint("maintenance_id", mn.ID))
-		return
-	}
-	mn.Statuses = append(mn.Statuses, db.IncidentStatus{
-		IncidentID: mn.ID,
-		Status:     event.MaintenanceCompleted,
-		Text:       "The maintenance is completed.",
-		Timestamp:  *mn.EndDate,
-	})
-
-	ch.log.Info("the status 'completed' was added", zap.Uint("maintenance_id", mn.ID))
-}
-
-func (ch *Checker) fixCancelledStatus(sHistory *StatusHistory, mn *db.Incident) {
-	ch.fixPlannedStatus(sHistory, mn)
+	wg.Wait()
 }
 
 func (ch *Checker) Run(done chan struct{}) {
@@ -198,9 +62,7 @@ func (ch *Checker) Run(done chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			if err := ch.Check(); err != nil {
-				ch.log.Error("error to check statuses", zap.Error(err))
-			}
+			ch.Check()
 		}
 	}
 }

--- a/internal/checker/info.go
+++ b/internal/checker/info.go
@@ -61,9 +61,6 @@ func (ch *Checker) CheckInfoEvents() error {
 		sHistory := calculateInfoStatusHistory(info)
 		actualStatus := calculateCurrentInfoStatus(sHistory, info)
 
-		// collect statuses for correction
-		missedStatuses := make([]db.IncidentStatus, 0)
-
 		switch actualStatus { //nolint:exhaustive
 		case event.InfoPlanned:
 			ch.fixInfoMissedStatuses(event.InfoPlanned, sHistory, info)
@@ -77,7 +74,6 @@ func (ch *Checker) CheckInfoEvents() error {
 			ch.fixInfoMissedStatuses(event.InfoCancelled, sHistory, info)
 		}
 
-		info.Statuses = append(info.Statuses, missedStatuses...)
 		err = ch.db.ModifyIncident(info)
 		if err != nil {
 			return err

--- a/internal/checker/info.go
+++ b/internal/checker/info.go
@@ -1,0 +1,202 @@
+//nolint:dupl
+package checker
+
+import (
+	"slices"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/stackmon/otc-status-dashboard/internal/db"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
+)
+
+type InfoStatusHistory struct {
+	hasPlanned   bool
+	hasActive    bool
+	hasCompleted bool
+	hasCancelled bool
+}
+
+func (st *InfoStatusHistory) hasStatus(status event.Status) bool {
+	switch status { //nolint:exhaustive
+	case event.InfoPlanned:
+		return st.hasPlanned
+	case event.InfoActive:
+		return st.hasActive
+	case event.InfoCompleted:
+		return st.hasCompleted
+	case event.InfoCancelled:
+		return st.hasCancelled
+	}
+	return false
+}
+
+func (st *InfoStatusHistory) setStatus(status event.Status) {
+	switch status { //nolint:exhaustive
+	case event.InfoPlanned:
+		st.hasPlanned = true
+	case event.InfoActive:
+		st.hasActive = true
+	case event.InfoCompleted:
+		st.hasCompleted = true
+	case event.InfoCancelled:
+		st.hasCancelled = true
+	}
+}
+
+func (ch *Checker) CheckInfoEvents() error {
+	ch.log.Info("check info event statuses")
+	if ch.lastInfoID == 0 {
+		ch.log.Info("no last completed info event, starting from the beginning")
+	}
+
+	infos, err := ch.db.GetInfoEvents(ch.lastInfoID)
+	if err != nil {
+		return err
+	}
+
+	var activeInfoEvents []uint
+	for _, info := range infos {
+		sHistory := calculateInfoStatusHistory(info)
+		actualStatus := calculateCurrentInfoStatus(sHistory, info)
+
+		// collect statuses for correction
+		missedStatuses := make([]db.IncidentStatus, 0)
+
+		switch actualStatus { //nolint:exhaustive
+		case event.InfoPlanned:
+			ch.fixInfoMissedStatuses(event.InfoPlanned, sHistory, info)
+			activeInfoEvents = append(activeInfoEvents, info.ID)
+		case event.InfoActive:
+			ch.fixInfoMissedStatuses(event.InfoActive, sHistory, info)
+			activeInfoEvents = append(activeInfoEvents, info.ID)
+		case event.InfoCompleted:
+			ch.fixInfoMissedStatuses(event.InfoCompleted, sHistory, info)
+		case event.InfoCancelled:
+			ch.fixInfoMissedStatuses(event.InfoCancelled, sHistory, info)
+		}
+
+		info.Statuses = append(info.Statuses, missedStatuses...)
+		err = ch.db.ModifyIncident(info)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(activeInfoEvents) == 0 {
+		for _, mn := range infos {
+			if mn.ID > ch.lastInfoID {
+				ch.lastInfoID = mn.ID
+			}
+		}
+		ch.log.Debug(
+			"there are no actual info events, set the last ID to the last one",
+			zap.Uint("lastInfoID", ch.lastInfoID),
+		)
+	} else {
+		ch.lastInfoID = slices.Min(activeInfoEvents)
+		ch.log.Debug(
+			"set the last ID to the earliest planned or in progress info event",
+			zap.Uint("lastInfoID", ch.lastInfoID),
+		)
+	}
+
+	ch.log.Info("finished checking info events")
+
+	return nil
+}
+
+func calculateInfoStatusHistory(mn *db.Incident) *InfoStatusHistory {
+	sHistory := &InfoStatusHistory{}
+	for _, st := range mn.Statuses {
+		if st.Status == event.InfoPlanned {
+			sHistory.hasPlanned = true
+		}
+		if st.Status == event.InfoActive {
+			sHistory.hasActive = true
+		}
+		if st.Status == event.InfoCompleted {
+			sHistory.hasCompleted = true
+		}
+		if st.Status == event.InfoCancelled {
+			sHistory.hasCancelled = true
+		}
+	}
+
+	return sHistory
+}
+
+func calculateCurrentInfoStatus(sHistory *InfoStatusHistory, info *db.Incident) event.Status {
+	if sHistory.hasCancelled {
+		return event.InfoCancelled
+	}
+
+	now := time.Now().UTC()
+
+	// calculate the mn current status
+	if info.StartDate.After(now) {
+		return event.InfoPlanned
+	}
+
+	if info.StartDate.Before(now) && info.EndDate.After(now) {
+		return event.InfoActive
+	}
+
+	return event.InfoCompleted
+}
+
+func (ch *Checker) fixInfoMissedStatuses(status event.Status, sHistory *InfoStatusHistory, info *db.Incident) {
+	ch.log.Info(
+		"start to fix missed statuses for the info event",
+		zap.String("targetStatus", string(status)), zap.Uint("infoID", info.ID),
+	)
+
+	var statusText string
+	var statusTimestamp time.Time
+
+	switch status { //nolint:exhaustive
+	case event.InfoPlanned:
+		ch.log.Info("fixing the planned status for the info event", zap.Uint("infoID", info.ID))
+		if sHistory.hasStatus(status) {
+			ch.log.Info("the info event is already has planned status", zap.Uint("infoID", info.ID))
+			return
+		}
+		statusText = event.InfoPlannedStatusText()
+		statusTimestamp = *info.StartDate
+
+	case event.InfoActive:
+		ch.log.Info("fixing the active status for the info event", zap.Uint("infoID", info.ID))
+		ch.fixInfoMissedStatuses(event.InfoPlanned, sHistory, info)
+		if sHistory.hasStatus(status) {
+			ch.log.Info("the info event is already has active status", zap.Uint("infoID", info.ID))
+			return
+		}
+		statusText = event.InfoActiveStatusText()
+		statusTimestamp = *info.StartDate
+
+	case event.InfoCompleted:
+		ch.log.Info("fixing the completed status for the info event", zap.Uint("infoID", info.ID))
+		ch.fixInfoMissedStatuses(event.InfoActive, sHistory, info)
+		if sHistory.hasStatus(status) {
+			ch.log.Info("the info event is already has completed status", zap.Uint("infoID", info.ID))
+			return
+		}
+		statusText = event.InfoCompletedStatusText()
+		statusTimestamp = *info.EndDate
+	case event.InfoCancelled:
+		ch.log.Info("fixing the cancelled status for the info event", zap.Uint("infoID", info.ID))
+		ch.fixInfoMissedStatuses(event.InfoPlanned, sHistory, info)
+		ch.log.Info("the info event is already has cancelled status", zap.Uint("infoID", info.ID))
+		return
+	}
+
+	info.Statuses = append(info.Statuses, db.IncidentStatus{
+		IncidentID: info.ID,
+		Status:     status,
+		Text:       statusText,
+		Timestamp:  statusTimestamp,
+	})
+	sHistory.setStatus(status)
+	ch.log.Info("the status was added", zap.String("status", string(status)), zap.Uint("infoID", info.ID))
+}

--- a/internal/checker/maintenance.go
+++ b/internal/checker/maintenance.go
@@ -1,0 +1,202 @@
+//nolint:dupl
+package checker
+
+import (
+	"slices"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/stackmon/otc-status-dashboard/internal/db"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
+)
+
+type MntStatusHistory struct {
+	hasPlanned    bool
+	hasInProgress bool
+	hasCompleted  bool
+	hasCancelled  bool
+}
+
+func (st *MntStatusHistory) hasStatus(status event.Status) bool {
+	switch status { //nolint:exhaustive
+	case event.MaintenancePlanned:
+		return st.hasPlanned
+	case event.MaintenanceInProgress:
+		return st.hasInProgress
+	case event.MaintenanceCompleted:
+		return st.hasCompleted
+	case event.MaintenanceCancelled:
+		return st.hasCancelled
+	}
+	return false
+}
+
+func (st *MntStatusHistory) setStatus(status event.Status) {
+	switch status { //nolint:exhaustive
+	case event.MaintenancePlanned:
+		st.hasPlanned = true
+	case event.MaintenanceInProgress:
+		st.hasInProgress = true
+	case event.MaintenanceCompleted:
+		st.hasCompleted = true
+	case event.MaintenanceCancelled:
+		st.hasCancelled = true
+	}
+}
+
+func (ch *Checker) CheckMaintenance() error {
+	ch.log.Info("check maintenances statuses")
+	if ch.lastMntID == 0 {
+		ch.log.Info("no last completed maintenance, starting from the beginning")
+	}
+
+	maintenances, err := ch.db.GetMaintenances(ch.lastMntID)
+	if err != nil {
+		return err
+	}
+
+	var activeMaintenances []uint
+	for _, mn := range maintenances {
+		sHistory := calculateMntStatusHistory(mn)
+		actualStatus := calculateCurrentMntStatus(sHistory, mn)
+
+		// collect statuses for correction
+		missedStatuses := make([]db.IncidentStatus, 0)
+
+		switch actualStatus { //nolint:exhaustive
+		case event.MaintenancePlanned:
+			ch.fixMntMissedStatuses(event.MaintenancePlanned, sHistory, mn)
+			activeMaintenances = append(activeMaintenances, mn.ID)
+		case event.MaintenanceInProgress:
+			ch.fixMntMissedStatuses(event.MaintenanceInProgress, sHistory, mn)
+			activeMaintenances = append(activeMaintenances, mn.ID)
+		case event.MaintenanceCompleted:
+			ch.fixMntMissedStatuses(event.MaintenanceCompleted, sHistory, mn)
+		case event.MaintenanceCancelled:
+			ch.fixMntMissedStatuses(event.MaintenanceCancelled, sHistory, mn)
+		}
+
+		mn.Statuses = append(mn.Statuses, missedStatuses...)
+		err = ch.db.ModifyIncident(mn)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(activeMaintenances) == 0 {
+		for _, mn := range maintenances {
+			if mn.ID > ch.lastMntID {
+				ch.lastMntID = mn.ID
+			}
+		}
+		ch.log.Debug(
+			"there are no actual maintenances, set the last ID to the last one",
+			zap.Uint("lastMntID", ch.lastMntID),
+		)
+	} else {
+		ch.lastMntID = slices.Min(activeMaintenances)
+		ch.log.Debug(
+			"set the last ID to the earliest planned or in progress maintenance",
+			zap.Uint("lastMntID", ch.lastMntID),
+		)
+	}
+
+	ch.log.Info("finished checking maintenances")
+
+	return nil
+}
+
+func calculateMntStatusHistory(mn *db.Incident) *MntStatusHistory {
+	sHistory := &MntStatusHistory{}
+	for _, st := range mn.Statuses {
+		if st.Status == event.MaintenancePlanned {
+			sHistory.hasPlanned = true
+		}
+		if st.Status == event.MaintenanceInProgress {
+			sHistory.hasInProgress = true
+		}
+		if st.Status == event.MaintenanceCompleted {
+			sHistory.hasCompleted = true
+		}
+		if st.Status == event.MaintenanceCancelled {
+			sHistory.hasCancelled = true
+		}
+	}
+
+	return sHistory
+}
+
+func calculateCurrentMntStatus(sHistory *MntStatusHistory, mn *db.Incident) event.Status {
+	if sHistory.hasCancelled {
+		return event.MaintenanceCancelled
+	}
+
+	now := time.Now().UTC()
+
+	// calculate the mn current status
+	if mn.StartDate.After(now) {
+		return event.MaintenancePlanned
+	}
+
+	if mn.StartDate.Before(now) && mn.EndDate.After(now) {
+		return event.MaintenanceInProgress
+	}
+
+	return event.MaintenanceCompleted
+}
+
+func (ch *Checker) fixMntMissedStatuses(status event.Status, sHistory *MntStatusHistory, mnt *db.Incident) {
+	ch.log.Info(
+		"start to fix missed statuses for the maintenance",
+		zap.String("targetStatus", string(status)), zap.Uint("mntID", mnt.ID),
+	)
+
+	var statusText string
+	var statusTimestamp time.Time
+
+	switch status { //nolint:exhaustive
+	case event.MaintenancePlanned:
+		ch.log.Info("fixing the planned status for the maintenance", zap.Uint("mntID", mnt.ID))
+		if sHistory.hasStatus(status) {
+			ch.log.Info("the maintenance is already has planned status", zap.Uint("mntID", mnt.ID))
+			return
+		}
+		statusText = event.MaintenancePlannedStatusText()
+		statusTimestamp = *mnt.StartDate
+
+	case event.MaintenanceInProgress:
+		ch.log.Info("fixing the active status for the maintenance", zap.Uint("mntID", mnt.ID))
+		ch.fixMntMissedStatuses(event.MaintenancePlanned, sHistory, mnt)
+		if sHistory.hasStatus(status) {
+			ch.log.Info("the maintenance is already has active status", zap.Uint("mntID", mnt.ID))
+			return
+		}
+		statusText = event.MaintenanceInProgressStatusText()
+		statusTimestamp = *mnt.StartDate
+
+	case event.MaintenanceCompleted:
+		ch.log.Info("fixing the completed status for the maintenance", zap.Uint("mntID", mnt.ID))
+		ch.fixMntMissedStatuses(event.MaintenanceInProgress, sHistory, mnt)
+		if sHistory.hasStatus(status) {
+			ch.log.Info("the maintenance is already has completed status", zap.Uint("mntID", mnt.ID))
+			return
+		}
+		statusText = event.MaintenanceCompletedStatusText()
+		statusTimestamp = *mnt.EndDate
+	case event.MaintenanceCancelled:
+		ch.log.Info("fixing the cancelled status for the maintenance", zap.Uint("mntID", mnt.ID))
+		ch.fixMntMissedStatuses(event.MaintenancePlanned, sHistory, mnt)
+		ch.log.Info("the maintenance is already has cancelled status", zap.Uint("mntID", mnt.ID))
+		return
+	}
+
+	mnt.Statuses = append(mnt.Statuses, db.IncidentStatus{
+		IncidentID: mnt.ID,
+		Status:     status,
+		Text:       statusText,
+		Timestamp:  statusTimestamp,
+	})
+	sHistory.setStatus(status)
+	ch.log.Info("the status was added", zap.String("status", string(status)), zap.Uint("mntID", mnt.ID))
+}

--- a/internal/checker/maintenance.go
+++ b/internal/checker/maintenance.go
@@ -61,9 +61,6 @@ func (ch *Checker) CheckMaintenance() error {
 		sHistory := calculateMntStatusHistory(mn)
 		actualStatus := calculateCurrentMntStatus(sHistory, mn)
 
-		// collect statuses for correction
-		missedStatuses := make([]db.IncidentStatus, 0)
-
 		switch actualStatus { //nolint:exhaustive
 		case event.MaintenancePlanned:
 			ch.fixMntMissedStatuses(event.MaintenancePlanned, sHistory, mn)
@@ -77,7 +74,6 @@ func (ch *Checker) CheckMaintenance() error {
 			ch.fixMntMissedStatuses(event.MaintenanceCancelled, sHistory, mn)
 		}
 
-		mn.Statuses = append(mn.Statuses, missedStatuses...)
 		err = ch.db.ModifyIncident(mn)
 		if err != nil {
 			return err

--- a/internal/db/info.go
+++ b/internal/db/info.go
@@ -6,14 +6,14 @@ import (
 	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
-func (db *DB) GetMaintenances(after uint) ([]*Incident, error) {
+func (db *DB) GetInfoEvents(after uint) ([]*Incident, error) {
 	var incidents []*Incident
 
 	r := db.g.Model(&Incident{}).
 		Preload("Statuses").
 		Preload("Components", func(db *gorm.DB) *gorm.DB { return db.Select("ID") })
 
-	r.Where("incident.type = ?", event.TypeMaintenance)
+	r.Where("incident.type = ?", event.TypeInformation)
 
 	if after > 0 {
 		r.Where("incident.id >= ?", after)

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -84,14 +84,34 @@ func IsIncidentClosedStatus(status Status) bool {
 }
 
 const (
-	maintenancePlannedText = "Maintenance is planned."
-	infoPlannedText        = "This informational notification is planned."
+	maintenancePlannedText    = "Maintenance is planned."
+	maintenanceInProgressText = "Maintenance is in progress."
+	maintenanceCompletedText  = "Maintenance is completed."
+	infoPlannedText           = "The informational notification is planned."
+	infoActiveText            = "The informational notification is active."
+	infoCompletedText         = "The informational notification is completed."
 )
 
 func MaintenancePlannedStatusText() string {
 	return maintenancePlannedText
 }
 
+func MaintenanceInProgressStatusText() string {
+	return maintenanceInProgressText
+}
+
+func MaintenanceCompletedStatusText() string {
+	return maintenanceCompletedText
+}
+
 func InfoPlannedStatusText() string {
 	return infoPlannedText
+}
+
+func InfoActiveStatusText() string {
+	return infoActiveText
+}
+
+func InfoCompletedStatusText() string {
+	return infoCompletedText
 }


### PR DESCRIPTION
Add functionality to check and fix statuses for info events. The same as for maintenance.

Close https://github.com/stackmon/status-dashboard-v3/issues/89