### PR TITLE
Fix time creation update

### DIFF
--- a/internal/api/v2/v2.go
+++ b/internal/api/v2/v2.go
@@ -384,6 +384,16 @@ func createEvent(dbInst *db.DB, log *zap.Logger, inc *db.Incident) error {
 	log.Info("add initial status to the event", zap.Uint("eventID", inc.ID))
 	var statusText string
 	var status event.Status
+	timestamp := time.Now().UTC()
+	// Sometimes we have a gap between the start date and the current time.
+	// Example: the incident was created now, but we add an update with a detected status since 1-2 seconds.
+	// And on the FE it looks like the incident was created in the past.
+	// it doesn't affect planned events, like maintenance or info, because they have a start date in the future.
+	// However, if someone creates an incident with a start date in the past, we should set up the right timestamp for the status update.
+	if inc.StartDate.Before(timestamp) {
+		timestamp = *inc.StartDate
+	}
+
 	switch inc.Type {
 	case event.TypeInformation:
 		statusText = event.InfoPlannedStatusText()
@@ -400,7 +410,7 @@ func createEvent(dbInst *db.DB, log *zap.Logger, inc *db.Incident) error {
 		IncidentID: inc.ID,
 		Status:     status,
 		Text:       statusText,
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  timestamp,
 	})
 
 	err = dbInst.ModifyIncident(inc)

--- a/internal/api/v2/v2.go
+++ b/internal/api/v2/v2.go
@@ -389,7 +389,8 @@ func createEvent(dbInst *db.DB, log *zap.Logger, inc *db.Incident) error {
 	// Example: the incident was created now, but we add an update with a detected status since 1-2 seconds.
 	// And on the FE it looks like the incident was created in the past.
 	// it doesn't affect planned events, like maintenance or info, because they have a start date in the future.
-	// However, if someone creates an incident with a start date in the past, we should set up the right timestamp for the status update.
+	// However, if someone creates an incident with a start date in the past,
+	// we should set up the right timestamp for the status update.
 	if inc.StartDate.Before(timestamp) {
 		timestamp = *inc.StartDate
 	}


### PR DESCRIPTION
Sometimes we have a gap between the start date and the current time. 

Example: the incident was created now, but we add an update with a detected status since 1-2 seconds.
And on the FE it looks like the incident was created in the past.

It doesn't affect planned events, like maintenance or info, because they have a start date in the future.
However, if someone creates an incident with a start date in the past, we should set up the right timestamp for the status update.