### PR TITLE
Refactor endpoins from /v2/incidents to /v2/events

### DIFF
--- a/docs/v2/v2_events.md
+++ b/docs/v2/v2_events.md
@@ -2,15 +2,26 @@
 
 ## Overview
 
-The `/v2/events` endpoint provides a paginated list of events, which can be incidents, maintenances, or informational events. This endpoint supports extensive filtering capabilities and pagination to allow clients to efficiently retrieve the data they need.
+The `/v2/events` endpoint provides full event management capabilities, including listing events with pagination, creating new events, updating existing events, and extracting components. This endpoint supports incidents, maintenances, and informational events.
 
-The existing `/v2/incidents` endpoint remains for backward compatibility and returns a complete, non-paginated list of incidents matching the filter criteria.
+The existing `/v2/incidents` endpoint remains for backward compatibility but is **deprecated**. All operations available on `/v2/incidents` are now also available on `/v2/events`:
+
+| Operation | Deprecated Endpoint | New Endpoint |
+|-----------|-------------------|--------------|
+| List events | `GET /v2/incidents` | `GET /v2/events` (with pagination) |
+| Create event | `POST /v2/incidents` | `POST /v2/events` |
+| Get event | `GET /v2/incidents/:eventID` | `GET /v2/events/:eventID` |
+| Update event | `PATCH /v2/incidents/:eventID` | `PATCH /v2/events/:eventID` |
+| Extract components | `POST /v2/incidents/:eventID/extract` | `POST /v2/events/:eventID/extract` |
+| Update event text | `PATCH /v2/incidents/:eventID/updates/:updateID` | `PATCH /v2/events/:eventID/updates/:updateID` |
+
+> **Note**: We recommend using `/v2/events` for all new integrations. The `/v2/incidents` endpoints will be removed in a future version.
 
 ## Handler Function: `GetEventsHandler`
 
 ### Description
 
-This handler is responsible for fetching events from the database. It is used by both `/v2/events` (with pagination) and `/v2/incidents` (without pagination).
+This handler is responsible for fetching events from the database. It is used by both `/v2/events` (with pagination) and `/v2/incidents` (without pagination, deprecated).
 
 - **Parameter Parsing**: It parses and validates query parameters for filtering and pagination.
 - **Data Retrieval**: Fetches a list of incidents from the database based on the provided filters. For paginated requests, it also retrieves the total count of matching records.
@@ -112,3 +123,110 @@ The handler returns a JSON object containing the list of events and pagination d
 - `recordsPerPage`: The number of records on the current page.
 - `totalRecords`: The total number of records matching the query.
 - `totalPages`: The total number of pages available.
+
+## Endpoint: `POST /v2/events`
+
+Creates a new event (incident, maintenance, or info).
+
+### Request
+
+- **Method**: `POST`
+- **Endpoint**: `/v2/events`
+- **Headers**:
+  - `Content-Type: application/json`
+  - `Authorization: Bearer <token>` (required)
+
+### Request Body
+
+```json
+{
+  "title": "OpenStack Upgrade in regions EU-DE/EU-NL",
+  "description": "Scheduled maintenance for OpenStack upgrade",
+  "impact": 0,
+  "components": [218, 254],
+  "start_date": "2025-05-20T10:00:00Z",
+  "end_date": "2025-05-20T14:00:00Z",
+  "system": false,
+  "type": "maintenance"
+}
+```
+
+See [v2_incident_creation.md](v2_incident_creation.md) for detailed documentation on event creation.
+
+## Endpoint: `GET /v2/events/:eventID`
+
+Retrieves a single event by its ID.
+
+### Request
+
+- **Method**: `GET`
+- **Endpoint**: `/v2/events/:eventID`
+
+### Response
+
+Returns the event object with all its details.
+
+## Endpoint: `PATCH /v2/events/:eventID`
+
+Updates an existing event.
+
+### Request
+
+- **Method**: `PATCH`
+- **Endpoint**: `/v2/events/:eventID`
+- **Headers**:
+  - `Content-Type: application/json`
+  - `Authorization: Bearer <token>` (required)
+
+### Request Body
+
+```json
+{
+  "title": "Updated title",
+  "description": "Updated description",
+  "impact": 2,
+  "status": "analysing",
+  "message": "Update message",
+  "update_date": "2025-05-20T11:00:00Z"
+}
+```
+
+## Endpoint: `POST /v2/events/:eventID/extract`
+
+Extracts components from an existing event into a new event.
+
+### Request
+
+- **Method**: `POST`
+- **Endpoint**: `/v2/events/:eventID/extract`
+- **Headers**:
+  - `Content-Type: application/json`
+  - `Authorization: Bearer <token>` (required)
+
+### Request Body
+
+```json
+{
+  "components": [254]
+}
+```
+
+## Endpoint: `PATCH /v2/events/:eventID/updates/:updateID`
+
+Updates the text of a specific event update.
+
+### Request
+
+- **Method**: `PATCH`
+- **Endpoint**: `/v2/events/:eventID/updates/:updateID`
+- **Headers**:
+  - `Content-Type: application/json`
+  - `Authorization: Bearer <token>` (required)
+
+### Request Body
+
+```json
+{
+  "text": "Updated status message"
+}
+```

--- a/docs/v2/v2_incident_creation.md
+++ b/docs/v2/v2_incident_creation.md
@@ -1,10 +1,12 @@
 # Incident management V2
 
-This document is described the business logic schema for incident management. All actions require authorisation.
+This document describes the business logic schema for incident management. All actions require authorisation.
 
 ## Incident creation
 
-For creation an incident, sent a POST request to endpoint `v2/incidents`.
+For creating an incident, send a POST request to endpoint `v2/events` (recommended) or `v2/incidents` (deprecated).
+
+> **Note**: The `/v2/incidents` endpoint is deprecated. Use `/v2/events` for all new integrations.
 
 The example:
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,6 +20,26 @@ import (
 
 const eventContextKey = "event"
 
+// EventIDToIncidentIDMW remaps :eventID parameter to work with handlers expecting :incidentID
+// This allows routes to use :eventID while keeping existing handler code unchanged
+// This helper will be removed in the next iteration.
+func EventIDToIncidentIDMW() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if eventID := c.Param("eventID"); eventID != "" {
+			newParams := make(gin.Params, 0, len(c.Params))
+			for _, param := range c.Params {
+				if param.Key == "eventID" {
+					newParams = append(newParams, gin.Param{Key: "incidentID", Value: param.Value})
+				} else {
+					newParams = append(newParams, param)
+				}
+			}
+			c.Params = newParams
+		}
+		c.Next()
+	}
+}
+
 func ValidateComponentsMW(dbInst *db.DB, logger *zap.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		logger.Info("start to validate given components")

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,26 +20,6 @@ import (
 
 const eventContextKey = "event"
 
-// EventIDToIncidentIDMW remaps :eventID parameter to work with handlers expecting :incidentID
-// This allows routes to use :eventID while keeping existing handler code unchanged
-// This helper will be removed in the next iteration.
-func EventIDToIncidentIDMW() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if eventID := c.Param("eventID"); eventID != "" {
-			newParams := make(gin.Params, 0, len(c.Params))
-			for _, param := range c.Params {
-				if param.Key == "eventID" {
-					newParams = append(newParams, gin.Param{Key: "incidentID", Value: param.Value})
-				} else {
-					newParams = append(newParams, param)
-				}
-			}
-			c.Params = newParams
-		}
-		c.Next()
-	}
-}
-
 func ValidateComponentsMW(dbInst *db.DB, logger *zap.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		logger.Info("start to validate given components")

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -55,17 +55,17 @@ func (a *API) InitRoutes() {
 			ValidateComponentsMW(a.db, a.log),
 			v2.PostIncidentHandler(a.db, a.log),
 		)
-		v2API.GET("incidents/:incidentID", v2.GetIncidentHandler(a.db, a.log))
-		v2API.PATCH("incidents/:incidentID",
+		v2API.GET("incidents/:eventID", v2.GetIncidentHandler(a.db, a.log))
+		v2API.PATCH("incidents/:eventID",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
 			v2.PatchIncidentHandler(a.db, a.log))
-		v2API.POST("incidents/:incidentID/extract",
+		v2API.POST("incidents/:eventID/extract",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
 			ValidateComponentsMW(a.db, a.log),
 			v2.PostIncidentExtractHandler(a.db, a.log))
-		v2API.PATCH("incidents/:incidentID/updates/:updateID",
+		v2API.PATCH("incidents/:eventID/updates/:updateID",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
 			v2.PatchEventUpdateTextHandler(a.db, a.log))
@@ -78,21 +78,17 @@ func (a *API) InitRoutes() {
 			ValidateComponentsMW(a.db, a.log),
 			v2.PostIncidentHandler(a.db, a.log))
 		v2API.GET("events/:eventID",
-			EventIDToIncidentIDMW(),
 			v2.GetIncidentHandler(a.db, a.log))
 		v2API.PATCH("events/:eventID",
-			EventIDToIncidentIDMW(),
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
 			v2.PatchIncidentHandler(a.db, a.log))
 		v2API.POST("events/:eventID/extract",
-			EventIDToIncidentIDMW(),
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
 			ValidateComponentsMW(a.db, a.log),
 			v2.PostIncidentExtractHandler(a.db, a.log))
 		v2API.PATCH("events/:eventID/updates/:updateID",
-			EventIDToIncidentIDMW(),
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
 			v2.PatchEventUpdateTextHandler(a.db, a.log))

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -59,7 +59,7 @@ func (a *API) InitRoutes() {
 		v2API.PATCH("incidents/:incidentID",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
-			v2.PatchEventHandler(a.db, a.log))
+			v2.PatchIncidentHandler(a.db, a.log))
 		v2API.POST("incidents/:incidentID/extract",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
@@ -84,7 +84,7 @@ func (a *API) InitRoutes() {
 			EventIDToIncidentIDMW(),
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
-			v2.PatchEventHandler(a.db, a.log))
+			v2.PatchIncidentHandler(a.db, a.log))
 		v2API.POST("events/:eventID/extract",
 			EventIDToIncidentIDMW(),
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -47,6 +47,8 @@ func (a *API) InitRoutes() {
 			v2.PostComponentHandler(a.db, a.log))
 		v2API.GET("components/:id", v2.GetComponentHandler(a.db, a.log))
 
+		// Incidents section. Deprecated.
+		// will be removed in a later version.
 		v2API.GET("incidents", v2.GetIncidentsHandler(a.db, a.log))
 		v2API.POST("incidents",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
@@ -57,7 +59,7 @@ func (a *API) InitRoutes() {
 		v2API.PATCH("incidents/:incidentID",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
-			v2.PatchIncidentHandler(a.db, a.log))
+			v2.PatchEventHandler(a.db, a.log))
 		v2API.POST("incidents/:incidentID/extract",
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
@@ -67,11 +69,37 @@ func (a *API) InitRoutes() {
 			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
 			CheckEventExistenceMW(a.db, a.log),
 			v2.PatchEventUpdateTextHandler(a.db, a.log))
-		// Paginated events.
+
+		// Events section.
+		// Get /v2/events returns events page with pagination.
 		v2API.GET("events", v2.GetEventsHandler(a.db, a.log))
+		v2API.POST("events",
+			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
+			ValidateComponentsMW(a.db, a.log),
+			v2.PostIncidentHandler(a.db, a.log))
+		v2API.GET("events/:eventID",
+			EventIDToIncidentIDMW(),
+			v2.GetIncidentHandler(a.db, a.log))
+		v2API.PATCH("events/:eventID",
+			EventIDToIncidentIDMW(),
+			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
+			CheckEventExistenceMW(a.db, a.log),
+			v2.PatchEventHandler(a.db, a.log))
+		v2API.POST("events/:eventID/extract",
+			EventIDToIncidentIDMW(),
+			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
+			CheckEventExistenceMW(a.db, a.log),
+			ValidateComponentsMW(a.db, a.log),
+			v2.PostIncidentExtractHandler(a.db, a.log))
+		v2API.PATCH("events/:eventID/updates/:updateID",
+			EventIDToIncidentIDMW(),
+			AuthenticationMW(a.oa2Prov, a.log, a.secretKeyV1, a.authGroup),
+			CheckEventExistenceMW(a.db, a.log),
+			v2.PatchEventUpdateTextHandler(a.db, a.log))
+		// Availability section.
 		v2API.GET("availability", v2.GetComponentsAvailabilityHandler(a.db, a.log))
 
-		// For testing purposes only
+		// For testing purposes only.
 		v2API.GET("rss/", newRSS.HandleRSS(a.db, a.log))
 	}
 

--- a/internal/api/v2/v2.go
+++ b/internal/api/v2/v2.go
@@ -945,7 +945,7 @@ type PatchIncidentData struct {
 	Type        string       `json:"type,omitempty" binding:"omitempty,oneof=maintenance info incident"`
 }
 
-func PatchEventHandler(dbInst *db.DB, logger *zap.Logger) gin.HandlerFunc {
+func PatchIncidentHandler(dbInst *db.DB, logger *zap.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		logger.Debug("update incident")
 

--- a/internal/api/v2/v2.go
+++ b/internal/api/v2/v2.go
@@ -22,7 +22,7 @@ const (
 
 // Event IDs and core data structures.
 type IncidentID struct {
-	ID int `json:"id" uri:"incidentID" binding:"required,gte=0"`
+	ID int `json:"id" uri:"eventID" binding:"required,gte=0"`
 }
 
 type IncidentData struct {
@@ -1546,7 +1546,7 @@ type EventUpdateData struct {
 
 func bindAndValidatePatchEventUpdate(c *gin.Context) (int, int, string, error) {
 	type updateData struct {
-		IncidentID int  `uri:"incidentID" binding:"required,gt=0"`
+		IncidentID int  `uri:"eventID" binding:"required,gt=0"`
 		UpdateID   *int `uri:"updateID" binding:"required,gte=0"`
 	}
 
@@ -1571,7 +1571,7 @@ func PatchEventUpdateTextHandler(dbInst *db.DB, logger *zap.Logger) gin.HandlerF
 	return func(c *gin.Context) {
 		logger.Debug(
 			"Patching text for event update",
-			zap.String("incidentID", c.Param("incidentID")),
+			zap.String("eventID", c.Param("eventID")),
 			zap.String("updateID", c.Param("updateID")),
 		)
 

--- a/internal/api/v2/v2.go
+++ b/internal/api/v2/v2.go
@@ -945,7 +945,7 @@ type PatchIncidentData struct {
 	Type        string       `json:"type,omitempty" binding:"omitempty,oneof=maintenance info incident"`
 }
 
-func PatchIncidentHandler(dbInst *db.DB, logger *zap.Logger) gin.HandlerFunc {
+func PatchEventHandler(dbInst *db.DB, logger *zap.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		logger.Debug("update incident")
 

--- a/internal/api/v2/v2_helpers_test.go
+++ b/internal/api/v2/v2_helpers_test.go
@@ -312,7 +312,7 @@ func prepareMockForModifyEventUpdate(
 func EventExistenceCheckForTests(dbInst *db.DB, _ *zap.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var uri struct {
-			ID uint `uri:"incidentID" binding:"required"`
+			ID uint `uri:"eventID" binding:"required"`
 		}
 		if err := c.ShouldBindUri(&uri); err != nil {
 			apiErrors.RaiseBadRequestErr(c, err)

--- a/internal/api/v2/v2_helpers_test.go
+++ b/internal/api/v2/v2_helpers_test.go
@@ -42,6 +42,7 @@ func initRoutes(t *testing.T, c *gin.Engine, dbInst *db.DB, log *zap.Logger) {
 		v2Api.GET("component_status", GetComponentsHandler(dbInst, log))
 		v2Api.POST("component_status", PostComponentHandler(dbInst, log))
 
+		// Incidents routes (deprecated)
 		v2Api.GET("incidents", GetIncidentsHandler(dbInst, log))
 		v2Api.POST("incidents", PostIncidentHandler(dbInst, log))
 		v2Api.GET("incidents/:eventID", GetIncidentHandler(dbInst, log))
@@ -50,7 +51,17 @@ func initRoutes(t *testing.T, c *gin.Engine, dbInst *db.DB, log *zap.Logger) {
 			EventExistenceCheckForTests(dbInst, log),
 			PatchEventUpdateTextHandler(dbInst, log),
 		)
+
+		// Events routes (new endpoints)
 		v2Api.GET("events", GetEventsHandler(dbInst, log))
+		v2Api.POST("events", PostIncidentHandler(dbInst, log))
+		v2Api.GET("events/:eventID", GetIncidentHandler(dbInst, log))
+		v2Api.PATCH("events/:eventID", PatchIncidentHandler(dbInst, log))
+		v2Api.PATCH("events/:eventID/updates/:updateID",
+			EventExistenceCheckForTests(dbInst, log),
+			PatchEventUpdateTextHandler(dbInst, log),
+		)
+
 		v2Api.GET("availability", GetComponentsAvailabilityHandler(dbInst, log))
 	}
 }

--- a/internal/api/v2/v2_helpers_test.go
+++ b/internal/api/v2/v2_helpers_test.go
@@ -45,7 +45,7 @@ func initRoutes(t *testing.T, c *gin.Engine, dbInst *db.DB, log *zap.Logger) {
 		v2Api.GET("incidents", GetIncidentsHandler(dbInst, log))
 		v2Api.POST("incidents", PostIncidentHandler(dbInst, log))
 		v2Api.GET("incidents/:incidentID", GetIncidentHandler(dbInst, log))
-		v2Api.PATCH("incidents/:incidentID", PatchEventHandler(dbInst, log))
+		v2Api.PATCH("incidents/:incidentID", PatchIncidentHandler(dbInst, log))
 		v2Api.PATCH("incidents/:incidentID/updates/:updateID",
 			EventExistenceCheckForTests(dbInst, log),
 			PatchEventUpdateTextHandler(dbInst, log),

--- a/internal/api/v2/v2_helpers_test.go
+++ b/internal/api/v2/v2_helpers_test.go
@@ -45,7 +45,7 @@ func initRoutes(t *testing.T, c *gin.Engine, dbInst *db.DB, log *zap.Logger) {
 		v2Api.GET("incidents", GetIncidentsHandler(dbInst, log))
 		v2Api.POST("incidents", PostIncidentHandler(dbInst, log))
 		v2Api.GET("incidents/:incidentID", GetIncidentHandler(dbInst, log))
-		v2Api.PATCH("incidents/:incidentID", PatchIncidentHandler(dbInst, log))
+		v2Api.PATCH("incidents/:incidentID", PatchEventHandler(dbInst, log))
 		v2Api.PATCH("incidents/:incidentID/updates/:updateID",
 			EventExistenceCheckForTests(dbInst, log),
 			PatchEventUpdateTextHandler(dbInst, log),

--- a/internal/api/v2/v2_helpers_test.go
+++ b/internal/api/v2/v2_helpers_test.go
@@ -44,9 +44,9 @@ func initRoutes(t *testing.T, c *gin.Engine, dbInst *db.DB, log *zap.Logger) {
 
 		v2Api.GET("incidents", GetIncidentsHandler(dbInst, log))
 		v2Api.POST("incidents", PostIncidentHandler(dbInst, log))
-		v2Api.GET("incidents/:incidentID", GetIncidentHandler(dbInst, log))
-		v2Api.PATCH("incidents/:incidentID", PatchIncidentHandler(dbInst, log))
-		v2Api.PATCH("incidents/:incidentID/updates/:updateID",
+		v2Api.GET("incidents/:eventID", GetIncidentHandler(dbInst, log))
+		v2Api.PATCH("incidents/:eventID", PatchIncidentHandler(dbInst, log))
+		v2Api.PATCH("incidents/:eventID/updates/:updateID",
 			EventExistenceCheckForTests(dbInst, log),
 			PatchEventUpdateTextHandler(dbInst, log),
 		)

--- a/internal/api/v2/v2_test.go
+++ b/internal/api/v2/v2_test.go
@@ -931,8 +931,9 @@ func TestPatchEventUpdateHandler(t *testing.T) {
 		expectedStatus int
 		expectedBody   string
 	}{
+		// Tests for /v2/incidents endpoint (deprecated)
 		{
-			name: "Update incident update id=0",
+			name: "Update incident update id=0 via /v2/incidents",
 			url:  fmt.Sprintf("incidents/111/updates/%d", updateIndex1),
 			body: `{"text": "Updated: analysing"}`,
 			mockSetup: func(m sqlmock.Sqlmock) {
@@ -947,8 +948,39 @@ func TestPatchEventUpdateHandler(t *testing.T) {
 			expectedBody:   responseAfterFirst,
 		},
 		{
-			name: "Update incident update id=1",
+			name: "Update incident update id=1 via /v2/incidents",
 			url:  fmt.Sprintf("incidents/111/updates/%d", updateIndex2),
+			body: `{"text": "Updated: resolved"}`,
+			mockSetup: func(m sqlmock.Sqlmock) {
+				prepareMockForPatchEventUpdate(
+					t, m, &incidentA,
+					uint(updateID2),
+					"Updated: resolved",
+					updateIndex2,
+				)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   responseAfterSecond,
+		},
+		// Tests for /v2/events endpoint (new)
+		{
+			name: "Update event update id=0 via /v2/events",
+			url:  fmt.Sprintf("events/111/updates/%d", updateIndex1),
+			body: `{"text": "Updated: analysing"}`,
+			mockSetup: func(m sqlmock.Sqlmock) {
+				prepareMockForPatchEventUpdate(
+					t, m, &incidentA,
+					uint(updateID1),
+					"Updated: analysing",
+					updateIndex1,
+				)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   responseAfterFirst,
+		},
+		{
+			name: "Update event update id=1 via /v2/events",
+			url:  fmt.Sprintf("events/111/updates/%d", updateIndex2),
 			body: `{"text": "Updated: resolved"}`,
 			mockSetup: func(m sqlmock.Sqlmock) {
 				prepareMockForPatchEventUpdate(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,6 +9,8 @@ tags:
     description: Authentication operations
   - name: incidents
     description: Incident management
+  - name: events
+    description: Event management
   - name: components
     description: Operations about components
   - name: v1
@@ -232,6 +234,7 @@ paths:
                       $ref: '#/components/schemas/ComponentAvailability'
   /v2/incidents:
     get:
+      deprecated: true
       summary: Get all incidents.
       tags:
         - incidents
@@ -252,6 +255,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Incidents'
     post:
+      deprecated: true
       summary: Create an incident.
       tags:
         - incidents
@@ -272,7 +276,7 @@ paths:
     get:
       summary: Get all events with pagination.
       tags:
-        - incidents
+        - events
       parameters:
         - $ref: '#/components/parameters/IncidentFilterType'
         - $ref: '#/components/parameters/IncidentFilterActive'
@@ -291,9 +295,152 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedEvents'
+    post:
+      summary: Create an event.
+      tags:
+        - events
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentPost'
+        required: true
+      responses:
+        '200':
+          description: Create an event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentPostResponse'
+
+  /v2/events/{event_id}:
+    get:
+      summary: Find an event by id.
+      description: Returns a single event.
+      tags:
+        - events
+      parameters:
+        - name: event_id
+          in: path
+          description: ID of event to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Event not found.
+    patch:
+      summary: Update an event.
+      tags:
+        - events
+      parameters:
+        - name: event_id
+          in: path
+          description: ID of event to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentPatch'
+        required: true
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Event not found.
+  /v2/events/{event_id}/extract:
+    post:
+      summary: Extract components to the new event
+      tags:
+        - events
+      parameters:
+        - name: event_id
+          in: path
+          description: ID of event
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentPostExtract'
+        required: true
+      responses:
+        '200':
+          description: successful operation, return the new event id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Event not found.
+  /v2/events/{event_id}/updates/{update_id}:
+    patch:
+      summary: Update the text of an event update.
+      tags:
+        - events
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: update_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                  example: "Updated status text"
+      responses:
+        '200':
+          description: Update successful.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventUpdateData'
+        '400':
+          description: Invalid input.
+        '404':
+          description: Not found.
 
   /v2/incidents/{incident_id}:
     get:
+      deprecated: true
       summary: Find an incident by id.
       description: Returns a single incident.
       tags:
@@ -318,6 +465,7 @@ paths:
         '404':
           description: Incident not found.
     patch:
+      deprecated: true
       summary: Update an incident.
       tags:
         - incidents
@@ -348,6 +496,7 @@ paths:
           description: Incident not found.
   /v2/incidents/{incident_id}/extract:
     post:
+      deprecated: true
       summary: extract components to the new incident
       tags:
         - incidents
@@ -378,6 +527,7 @@ paths:
           description: Incident not found.
   /v2/incidents/{incident_id}/updates/{update_id}:
     patch:
+      deprecated: true
       summary: Update the text of an incident update.
       tags:
         - incidents

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -175,16 +175,16 @@ func initRoutesV2(t *testing.T, c *gin.Engine, dbInst *db.DB, logger *zap.Logger
 	// They will be removed in the next iteration.
 	v2Api.GET("incidents", v2.GetIncidentsHandler(dbInst, logger))
 	v2Api.POST("incidents", api.ValidateComponentsMW(dbInst, logger), v2.PostIncidentHandler(dbInst, logger))
-	v2Api.GET("incidents/:incidentID",
+	v2Api.GET("incidents/:eventID",
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.GetIncidentHandler(dbInst, logger))
-	v2Api.PATCH("incidents/:incidentID",
+	v2Api.PATCH("incidents/:eventID",
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PatchIncidentHandler(dbInst, logger))
-	v2Api.POST("incidents/:incidentID/extract",
+	v2Api.POST("incidents/:eventID/extract",
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PostIncidentExtractHandler(dbInst, logger))
-	v2Api.PATCH("incidents/:incidentID/updates/:updateID",
+	v2Api.PATCH("incidents/:eventID/updates/:updateID",
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PatchEventUpdateTextHandler(dbInst, logger))
 
@@ -192,19 +192,15 @@ func initRoutesV2(t *testing.T, c *gin.Engine, dbInst *db.DB, logger *zap.Logger
 	v2Api.GET("events", v2.GetEventsHandler(dbInst, logger))
 	v2Api.POST("events", api.ValidateComponentsMW(dbInst, logger), v2.PostIncidentHandler(dbInst, logger))
 	v2Api.GET("events/:eventID",
-		api.EventIDToIncidentIDMW(),
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.GetIncidentHandler(dbInst, logger))
 	v2Api.PATCH("events/:eventID",
-		api.EventIDToIncidentIDMW(),
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PatchIncidentHandler(dbInst, logger))
 	v2Api.POST("events/:eventID/extract",
-		api.EventIDToIncidentIDMW(),
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PostIncidentExtractHandler(dbInst, logger))
 	v2Api.PATCH("events/:eventID/updates/:updateID",
-		api.EventIDToIncidentIDMW(),
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PatchEventUpdateTextHandler(dbInst, logger))
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -180,7 +180,7 @@ func initRoutesV2(t *testing.T, c *gin.Engine, dbInst *db.DB, logger *zap.Logger
 		v2.GetIncidentHandler(dbInst, logger))
 	v2Api.PATCH("incidents/:incidentID",
 		api.CheckEventExistenceMW(dbInst, logger),
-		v2.PatchEventHandler(dbInst, logger))
+		v2.PatchIncidentHandler(dbInst, logger))
 	v2Api.POST("incidents/:incidentID/extract",
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PostIncidentExtractHandler(dbInst, logger))
@@ -198,7 +198,7 @@ func initRoutesV2(t *testing.T, c *gin.Engine, dbInst *db.DB, logger *zap.Logger
 	v2Api.PATCH("events/:eventID",
 		api.EventIDToIncidentIDMW(),
 		api.CheckEventExistenceMW(dbInst, logger),
-		v2.PatchEventHandler(dbInst, logger))
+		v2.PatchIncidentHandler(dbInst, logger))
 	v2Api.POST("events/:eventID/extract",
 		api.EventIDToIncidentIDMW(),
 		api.CheckEventExistenceMW(dbInst, logger),

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -171,6 +171,8 @@ func initRoutesV2(t *testing.T, c *gin.Engine, dbInst *db.DB, logger *zap.Logger
 	v2Api.POST("components", v2.PostComponentHandler(dbInst, logger))
 	v2Api.GET("components/:id", v2.GetComponentHandler(dbInst, logger))
 
+	// Incidents routes are deprecated.
+	// They will be removed in the next iteration.
 	v2Api.GET("incidents", v2.GetIncidentsHandler(dbInst, logger))
 	v2Api.POST("incidents", api.ValidateComponentsMW(dbInst, logger), v2.PostIncidentHandler(dbInst, logger))
 	v2Api.GET("incidents/:incidentID",
@@ -178,14 +180,34 @@ func initRoutesV2(t *testing.T, c *gin.Engine, dbInst *db.DB, logger *zap.Logger
 		v2.GetIncidentHandler(dbInst, logger))
 	v2Api.PATCH("incidents/:incidentID",
 		api.CheckEventExistenceMW(dbInst, logger),
-		v2.PatchIncidentHandler(dbInst, logger))
+		v2.PatchEventHandler(dbInst, logger))
 	v2Api.POST("incidents/:incidentID/extract",
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PostIncidentExtractHandler(dbInst, logger))
 	v2Api.PATCH("incidents/:incidentID/updates/:updateID",
 		api.CheckEventExistenceMW(dbInst, logger),
 		v2.PatchEventUpdateTextHandler(dbInst, logger))
+
+	// Events routes.
 	v2Api.GET("events", v2.GetEventsHandler(dbInst, logger))
+	v2Api.POST("events", api.ValidateComponentsMW(dbInst, logger), v2.PostIncidentHandler(dbInst, logger))
+	v2Api.GET("events/:eventID",
+		api.EventIDToIncidentIDMW(),
+		api.CheckEventExistenceMW(dbInst, logger),
+		v2.GetIncidentHandler(dbInst, logger))
+	v2Api.PATCH("events/:eventID",
+		api.EventIDToIncidentIDMW(),
+		api.CheckEventExistenceMW(dbInst, logger),
+		v2.PatchEventHandler(dbInst, logger))
+	v2Api.POST("events/:eventID/extract",
+		api.EventIDToIncidentIDMW(),
+		api.CheckEventExistenceMW(dbInst, logger),
+		v2.PostIncidentExtractHandler(dbInst, logger))
+	v2Api.PATCH("events/:eventID/updates/:updateID",
+		api.EventIDToIncidentIDMW(),
+		api.CheckEventExistenceMW(dbInst, logger),
+		v2.PatchEventUpdateTextHandler(dbInst, logger))
+
 	v2Api.GET("availability", v2.GetComponentsAvailabilityHandler(dbInst, logger))
 }
 

--- a/tests/v2_events_test.go
+++ b/tests/v2_events_test.go
@@ -1,46 +1,46 @@
 package tests
 
 import (
-"bytes"
-"encoding/json"
-"fmt"
-"net/http"
-"net/http/httptest"
-"strings"
-"testing"
-"time"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
 
-"github.com/gin-gonic/gin"
-"github.com/stretchr/testify/assert"
-"github.com/stretchr/testify/require"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-v2 "github.com/stackmon/otc-status-dashboard/internal/api/v2"
-"github.com/stackmon/otc-status-dashboard/internal/event"
+	v2 "github.com/stackmon/otc-status-dashboard/internal/api/v2"
+	"github.com/stackmon/otc-status-dashboard/internal/event"
 )
 
 // V2EventsListResponse defines the expected structure for the GET /v2/events endpoint.
 type V2EventsListResponse struct {
-Data       []*v2.Incident `json:"data"`
-Message    string         `json:"message,omitempty"`
-Pagination *struct {
-PageIndex      int `json:"pageIndex"`
-RecordsPerPage int `json:"recordsPerPage"`
-TotalRecords   int `json:"totalRecords"`
-TotalPages     int `json:"totalPages"`
-} `json:"pagination,omitempty"`
+	Data       []*v2.Incident `json:"data"`
+	Message    string         `json:"message,omitempty"`
+	Pagination *struct {
+		PageIndex      int `json:"pageIndex"`
+		RecordsPerPage int `json:"recordsPerPage"`
+		TotalRecords   int `json:"totalRecords"`
+		TotalPages     int `json:"totalPages"`
+	} `json:"pagination,omitempty"`
 }
 
 func TestV2PostEventsHandlerNegative(t *testing.T) {
-t.Log("start to test incident creation and check json data for /v2/events")
-r, _, _ := initTests(t)
+	t.Log("start to test incident creation and check json data for /v2/events")
+	r, _, _ := initTests(t)
 
-type testCase struct {
-ExpectedCode int
-Expected     string
-JSON         string
-}
+	type testCase struct {
+		ExpectedCode int
+		Expected     string
+		JSON         string
+	}
 
-jsEndPresent := `{
+	jsEndPresent := `{
   "title":"OpenStack Upgrade in regions EU-DE/EU-NL",
   "impact":1,
   "components":[
@@ -59,7 +59,7 @@ jsEndPresent := `{
     }
   ]
 }`
-jsUpdatesPresent := `{
+	jsUpdatesPresent := `{
   "title":"OpenStack Upgrade in regions EU-DE/EU-NL",
   "impact":1,
   "components":[
@@ -77,7 +77,7 @@ jsUpdatesPresent := `{
     }
   ]
 }`
-jsWrongComponents := `{
+	jsWrongComponents := `{
   "title":"OpenStack Upgrade in regions EU-DE/EU-NL",
   "impact":1,
   "components":[
@@ -88,7 +88,7 @@ jsWrongComponents := `{
   "system":false,
   "type":"incident"
 }`
-jsWrongMaintenanceImpact := `{
+	jsWrongMaintenanceImpact := `{
   "title":"Maintenance with wrong impact",
   "impact":1,
   "components":[1],
@@ -97,7 +97,7 @@ jsWrongMaintenanceImpact := `{
   "type":"maintenance"
 }`
 
-jsWrongIncidentImpact := `{
+	jsWrongIncidentImpact := `{
   "title":"event with maintenance impact",
   "impact":0,
   "components":[1],
@@ -106,230 +106,230 @@ jsWrongIncidentImpact := `{
   "type":"incident"
 }`
 
-testCases := map[string]*testCase{
-"negative testcase, event is not a maintenance and end_date is present": {
-JSON:         jsEndPresent,
-Expected:     `{"errMsg":"event end_date should be empty"}`,
-ExpectedCode: 400,
-},
-"negative testcase, updates are present": {
-JSON:         jsUpdatesPresent,
-Expected:     `{"errMsg":"event updates should be empty"}`,
-ExpectedCode: 400,
-},
-"negative testcase, wrong components ids": {
-JSON:         jsWrongComponents,
-Expected:     `{"errMsg":"component does not exist, component_id: 218"}`,
-ExpectedCode: 400,
-},
-"negative testcase, maintenance with non-zero impact": {
-JSON:         jsWrongMaintenanceImpact,
-Expected:     `{"errMsg":"impact must be 0 for type 'maintenance' or 'info' and gt 0 for 'incident'"}`,
-ExpectedCode: 400,
-},
-"negative testcase, event with zero impact": {
-JSON:         jsWrongIncidentImpact,
-Expected:     `{"errMsg":"impact must be 0 for type 'maintenance' or 'info' and gt 0 for 'incident'"}`,
-ExpectedCode: 400,
-},
-}
+	testCases := map[string]*testCase{
+		"negative testcase, event is not a maintenance and end_date is present": {
+			JSON:         jsEndPresent,
+			Expected:     `{"errMsg":"event end_date should be empty"}`,
+			ExpectedCode: 400,
+		},
+		"negative testcase, updates are present": {
+			JSON:         jsUpdatesPresent,
+			Expected:     `{"errMsg":"event updates should be empty"}`,
+			ExpectedCode: 400,
+		},
+		"negative testcase, wrong components ids": {
+			JSON:         jsWrongComponents,
+			Expected:     `{"errMsg":"component does not exist, component_id: 218"}`,
+			ExpectedCode: 400,
+		},
+		"negative testcase, maintenance with non-zero impact": {
+			JSON:         jsWrongMaintenanceImpact,
+			Expected:     `{"errMsg":"impact must be 0 for type 'maintenance' or 'info' and gt 0 for 'incident'"}`,
+			ExpectedCode: 400,
+		},
+		"negative testcase, event with zero impact": {
+			JSON:         jsWrongIncidentImpact,
+			Expected:     `{"errMsg":"impact must be 0 for type 'maintenance' or 'info' and gt 0 for 'incident'"}`,
+			ExpectedCode: 400,
+		},
+	}
 
-for title, c := range testCases {
-t.Logf("start test case: %s\n", title)
+	for title, c := range testCases {
+		t.Logf("start test case: %s\n", title)
 
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, strings.NewReader(c.JSON))
-r.ServeHTTP(w, req)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, strings.NewReader(c.JSON))
+		r.ServeHTTP(w, req)
 
-assert.Equal(t, c.ExpectedCode, w.Code)
-assert.Equal(t, c.Expected, w.Body.String())
-}
+		assert.Equal(t, c.ExpectedCode, w.Code)
+		assert.Equal(t, c.Expected, w.Body.String())
+	}
 }
 
 func TestV2PostEventsHandler(t *testing.T) {
-t.Log("start to test incident creation for /v2/events")
-r, _, _ := initTests(t)
+	t.Log("start to test incident creation for /v2/events")
+	r, _, _ := initTests(t)
 
-t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
-incidents := v2GetEvents(t, r)
-for _, inc := range incidents {
-if inc.EndDate == nil {
-endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
-inc.EndDate = &endDate
-v2PatchEvent(t, r, inc)
-}
-if inc.Type == event.TypeMaintenance {
-t.Log("the component is maintenance, cancel it")
-v2PatchEvent(t, r, inc, event.MaintenanceCancelled)
-}
-}
+	t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
+	incidents := v2GetEvents(t, r)
+	for _, inc := range incidents {
+		if inc.EndDate == nil {
+			endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
+			inc.EndDate = &endDate
+			v2PatchEvent(t, r, inc)
+		}
+		if inc.Type == event.TypeMaintenance {
+			t.Log("the component is maintenance, cancel it")
+			v2PatchEvent(t, r, inc, event.MaintenanceCancelled)
+		}
+	}
 
-components := []int{1, 2}
-impact := 1
-title := "Test incident creation for api V2 for components: 1, 2. Test 1."
-description := "any description for incident"
-startDate := time.Now().AddDate(0, 0, -1).UTC()
-system := false
-incType := event.TypeIncident
+	components := []int{1, 2}
+	impact := 1
+	title := "Test incident creation for api V2 for components: 1, 2. Test 1."
+	description := "any description for incident"
+	startDate := time.Now().AddDate(0, 0, -1).UTC()
+	system := false
+	incType := event.TypeIncident
 
-incidentCreateData := v2.IncidentData{
-Title:       title,
-Description: description,
-Impact:      &impact,
-Components:  components,
-StartDate:   startDate,
-System:      &system,
-Type:        incType,
-}
+	incidentCreateData := v2.IncidentData{
+		Title:       title,
+		Description: description,
+		Impact:      &impact,
+		Components:  components,
+		StartDate:   startDate,
+		System:      &system,
+		Type:        incType,
+	}
 
-result := v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, result, "v2CreateEvent returned nil")
+	result := v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, result, "v2CreateEvent returned nil")
 
-assert.Len(t, result.Result, len(incidentCreateData.Components))
-assert.Empty(t, result.Result[0].Error)
-assert.Empty(t, result.Result[1].Error)
-assert.Equal(t, len(incidents)+1, result.Result[0].IncidentID)
-assert.Equal(t, len(incidents)+1, result.Result[1].IncidentID)
+	assert.Len(t, result.Result, len(incidentCreateData.Components))
+	assert.Empty(t, result.Result[0].Error)
+	assert.Empty(t, result.Result[1].Error)
+	assert.Equal(t, len(incidents)+1, result.Result[0].IncidentID)
+	assert.Equal(t, len(incidents)+1, result.Result[1].IncidentID)
 
-t.Log("check created incident data, incident id: ", result.Result[0].IncidentID)
-incident := v2GetEvent(t, r, result.Result[0].IncidentID)
-assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
-assert.Equal(t, title, incident.Title)
-assert.Equal(t, impact, *incident.Impact)
-assert.Equal(t, system, *incident.System)
-assert.Nil(t, incident.EndDate)
-require.NotNil(t, incident.Type)
-assert.Equal(t, event.TypeIncident, incident.Type)
-require.NotNil(t, incident.Updates)
-assert.Equal(t, "The incident is detected.", incident.Updates[0].Text)
+	t.Log("check created incident data, incident id: ", result.Result[0].IncidentID)
+	incident := v2GetEvent(t, r, result.Result[0].IncidentID)
+	assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
+	assert.Equal(t, title, incident.Title)
+	assert.Equal(t, impact, *incident.Impact)
+	assert.Equal(t, system, *incident.System)
+	assert.Nil(t, incident.EndDate)
+	require.NotNil(t, incident.Type)
+	assert.Equal(t, event.TypeIncident, incident.Type)
+	require.NotNil(t, incident.Updates)
+	assert.Equal(t, "The incident is detected.", incident.Updates[0].Text)
 
-t.Log("create a new incident with the same components and the same impact, should close previous and move components to the new")
-t.Log("current time:", time.Now().UTC())
-incidentCreateData.Title = "Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new."
-result = v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, result, "v2CreateEvent returned nil")
-assert.Equal(t, len(incidents)+2, result.Result[0].IncidentID)
-assert.Equal(t, len(incidents)+2, result.Result[1].IncidentID)
+	t.Log("create a new incident with the same components and the same impact, should close previous and move components to the new")
+	t.Log("current time:", time.Now().UTC())
+	incidentCreateData.Title = "Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new."
+	result = v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, result, "v2CreateEvent returned nil")
+	assert.Equal(t, len(incidents)+2, result.Result[0].IncidentID)
+	assert.Equal(t, len(incidents)+2, result.Result[1].IncidentID)
 
-oldIncident := v2GetEvent(t, r, result.Result[0].IncidentID-1)
-assert.NotNil(t, oldIncident.EndDate)
-assert.Len(t, oldIncident.Components, 1)
-assert.NotNil(t, oldIncident.Updates)
-assert.Len(t, oldIncident.Updates, 3)
-t.Logf("STATUS updates: %v", oldIncident.Updates)
-assert.Equal(t, event.IncidentDetected, oldIncident.Updates[0].Status)
-assert.Equal(t, event.OutDatedSystem, oldIncident.Updates[1].Status)
-assert.Equal(t, event.IncidentResolved, oldIncident.Updates[2].Status)
-assert.Equal(t, "The incident is detected.", oldIncident.Updates[0].Text)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>", result.Result[0].IncidentID), oldIncident.Updates[1].Text)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>, Incident closed by system", result.Result[0].IncidentID), oldIncident.Updates[2].Text)
+	oldIncident := v2GetEvent(t, r, result.Result[0].IncidentID-1)
+	assert.NotNil(t, oldIncident.EndDate)
+	assert.Len(t, oldIncident.Components, 1)
+	assert.NotNil(t, oldIncident.Updates)
+	assert.Len(t, oldIncident.Updates, 3)
+	t.Logf("STATUS updates: %v", oldIncident.Updates)
+	assert.Equal(t, event.IncidentDetected, oldIncident.Updates[0].Status)
+	assert.Equal(t, event.OutDatedSystem, oldIncident.Updates[1].Status)
+	assert.Equal(t, event.IncidentResolved, oldIncident.Updates[2].Status)
+	assert.Equal(t, "The incident is detected.", oldIncident.Updates[0].Text)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>", result.Result[0].IncidentID), oldIncident.Updates[1].Text)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>, Incident closed by system", result.Result[0].IncidentID), oldIncident.Updates[2].Text)
 
-incidentN3 := v2GetEvent(t, r, result.Result[0].IncidentID)
-assert.Nil(t, incidentN3.EndDate)
-assert.Len(t, incidentN3.Components, 2)
-assert.NotNil(t, incidentN3.Updates)
-assert.Len(t, incidentN3.Updates, 3)
-assert.Equal(t, event.IncidentDetected, incidentN3.Updates[0].Status)
-assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
-assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[2].Status)
-assert.Equal(t, "The incident is detected.", incidentN3.Updates[0].Text)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", result.Result[0].IncidentID-1), incidentN3.Updates[1].Text)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", result.Result[0].IncidentID-1), incidentN3.Updates[2].Text)
+	incidentN3 := v2GetEvent(t, r, result.Result[0].IncidentID)
+	assert.Nil(t, incidentN3.EndDate)
+	assert.Len(t, incidentN3.Components, 2)
+	assert.NotNil(t, incidentN3.Updates)
+	assert.Len(t, incidentN3.Updates, 3)
+	assert.Equal(t, event.IncidentDetected, incidentN3.Updates[0].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[2].Status)
+	assert.Equal(t, "The incident is detected.", incidentN3.Updates[0].Text)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", result.Result[0].IncidentID-1), incidentN3.Updates[1].Text)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", result.Result[0].IncidentID-1), incidentN3.Updates[2].Text)
 
-t.Log("create a new maintenance with the same components and higher impact, should create a new without components")
+	t.Log("create a new maintenance with the same components and higher impact, should create a new without components")
 
-impact = 0
-title = "Test maintenance creation for api V2 for the components: 1-Cloud Container Engine (Container, EU-DE, cce), 2-Cloud Container Engine (Container, EU-NL, cce)"
-incidentCreateData.Title = title
-incidentCreateData.Description = "any description for maintenance incident"
-endDate := time.Now().AddDate(0, 0, 1).UTC()
-incidentCreateData.EndDate = &endDate
-incidentCreateData.Type = event.TypeMaintenance
+	impact = 0
+	title = "Test maintenance creation for api V2 for the components: 1-Cloud Container Engine (Container, EU-DE, cce), 2-Cloud Container Engine (Container, EU-NL, cce)"
+	incidentCreateData.Title = title
+	incidentCreateData.Description = "any description for maintenance incident"
+	endDate := time.Now().AddDate(0, 0, 1).UTC()
+	incidentCreateData.EndDate = &endDate
+	incidentCreateData.Type = event.TypeMaintenance
 
-result = v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, result, "v2CreateEvent returned nil")
-assert.Equal(t, len(incidents)+3, result.Result[0].IncidentID)
-assert.Equal(t, len(incidents)+3, result.Result[1].IncidentID)
+	result = v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, result, "v2CreateEvent returned nil")
+	assert.Equal(t, len(incidents)+3, result.Result[0].IncidentID)
+	assert.Equal(t, len(incidents)+3, result.Result[1].IncidentID)
 
-maintenanceIncident := v2GetEvent(t, r, result.Result[0].IncidentID)
-assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), maintenanceIncident.StartDate)
-require.NotNil(t, incidentCreateData.EndDate)
-require.NotNil(t, maintenanceIncident.EndDate)
-assert.Equal(t, incidentCreateData.EndDate.Truncate(time.Microsecond), maintenanceIncident.EndDate.Truncate(time.Microsecond))
-assert.Equal(t, title, maintenanceIncident.Title)
-assert.Equal(t, impact, *maintenanceIncident.Impact)
-assert.Equal(t, system, *maintenanceIncident.System)
-assert.Equal(t, incidentCreateData.Description, maintenanceIncident.Description)
-assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
-require.NotNil(t, maintenanceIncident.Type)
-assert.Equal(t, event.TypeMaintenance, maintenanceIncident.Type)
-assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
+	maintenanceIncident := v2GetEvent(t, r, result.Result[0].IncidentID)
+	assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), maintenanceIncident.StartDate)
+	require.NotNil(t, incidentCreateData.EndDate)
+	require.NotNil(t, maintenanceIncident.EndDate)
+	assert.Equal(t, incidentCreateData.EndDate.Truncate(time.Microsecond), maintenanceIncident.EndDate.Truncate(time.Microsecond))
+	assert.Equal(t, title, maintenanceIncident.Title)
+	assert.Equal(t, impact, *maintenanceIncident.Impact)
+	assert.Equal(t, system, *maintenanceIncident.System)
+	assert.Equal(t, incidentCreateData.Description, maintenanceIncident.Description)
+	assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
+	require.NotNil(t, maintenanceIncident.Type)
+	assert.Equal(t, event.TypeMaintenance, maintenanceIncident.Type)
+	assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
 
-incidentN3 = v2GetEvent(t, r, result.Result[0].IncidentID-1)
-assert.Nil(t, incidentN3.EndDate)
-assert.Len(t, incidentN3.Components, 2)
-assert.NotNil(t, incidentN3.Updates)
-assert.Len(t, incidentN3.Updates, 3)
-assert.Equal(t, event.IncidentDetected, incidentN3.Updates[0].Status)
-assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
-assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
-assert.Equal(t, "The incident is detected.", incidentN3.Updates[0].Text)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", incidentN3.ID-1), incidentN3.Updates[1].Text)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", incidentN3.ID-1), incidentN3.Updates[2].Text)
-require.NotNil(t, incidentN3.Type)
-assert.Equal(t, event.TypeIncident, incidentN3.Type)
+	incidentN3 = v2GetEvent(t, r, result.Result[0].IncidentID-1)
+	assert.Nil(t, incidentN3.EndDate)
+	assert.Len(t, incidentN3.Components, 2)
+	assert.NotNil(t, incidentN3.Updates)
+	assert.Len(t, incidentN3.Updates, 3)
+	assert.Equal(t, event.IncidentDetected, incidentN3.Updates[0].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
+	assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
+	assert.Equal(t, "The incident is detected.", incidentN3.Updates[0].Text)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", incidentN3.ID-1), incidentN3.Updates[1].Text)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", incidentN3.ID-1), incidentN3.Updates[2].Text)
+	require.NotNil(t, incidentN3.Type)
+	assert.Equal(t, event.TypeIncident, incidentN3.Type)
 
-t.Log("check response, if incident component is not present in the opened incidents, should create a new incident")
-components = []int{3}
-impact = 1
-incidentCreateData = v2.IncidentData{
-Title:       "Test for another different component id: 3.",
-Description: "Any description for incident with different component",
-Impact:      &impact,
-Components:  components,
-StartDate:   startDate,
-System:      &system,
-Type:        event.TypeIncident,
-}
-result = v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, result, "v2CreateEvent returned nil")
-// ID should be incidentN3.ID + 2 (maintenance + this new incident)
-expectedID := incidentN3.ID + 2
-assert.Equal(t, expectedID, result.Result[0].IncidentID)
-assert.Equal(t, 3, result.Result[0].ComponentID)
+	t.Log("check response, if incident component is not present in the opened incidents, should create a new incident")
+	components = []int{3}
+	impact = 1
+	incidentCreateData = v2.IncidentData{
+		Title:       "Test for another different component id: 3.",
+		Description: "Any description for incident with different component",
+		Impact:      &impact,
+		Components:  components,
+		StartDate:   startDate,
+		System:      &system,
+		Type:        event.TypeIncident,
+	}
+	result = v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, result, "v2CreateEvent returned nil")
+	// ID should be incidentN3.ID + 2 (maintenance + this new incident)
+	expectedID := incidentN3.ID + 2
+	assert.Equal(t, expectedID, result.Result[0].IncidentID)
+	assert.Equal(t, 3, result.Result[0].ComponentID)
 }
 
 func TestV2PatchEventHandlerNegative(t *testing.T) {
-t.Log("start to test negative cases for incident patching and check json data for /v2/events/42")
-r, _, _ := initTests(t)
+	t.Log("start to test negative cases for incident patching and check json data for /v2/events/42")
+	r, _, _ := initTests(t)
 
-components := []int{1}
-impact := 1
-title := "Incident for negative tests for incident patching"
-startDate := time.Now().AddDate(0, 0, -1).UTC()
-system := false
+	components := []int{1}
+	impact := 1
+	title := "Incident for negative tests for incident patching"
+	startDate := time.Now().AddDate(0, 0, -1).UTC()
+	system := false
 
-incidentCreateData := v2.IncidentData{
-Title:       title,
-Description: "any description for incident",
-Impact:      &impact,
-Components:  components,
-StartDate:   startDate,
-System:      &system,
-Type:        event.TypeIncident,
-}
+	incidentCreateData := v2.IncidentData{
+		Title:       title,
+		Description: "any description for incident",
+		Impact:      &impact,
+		Components:  components,
+		StartDate:   startDate,
+		System:      &system,
+		Type:        event.TypeIncident,
+	}
 
-resp := v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, resp, "v2CreateEvent returned nil")
-incID10 := resp.Result[0].IncidentID
+	resp := v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, resp, "v2CreateEvent returned nil")
+	incID10 := resp.Result[0].IncidentID
 
-type testCase struct {
-ExpectedCode int
-Expected     string
-JSON         string
-}
+	type testCase struct {
+		ExpectedCode int
+		Expected     string
+		JSON         string
+	}
 
-jsWrongOpenedStatus := `{
+	jsWrongOpenedStatus := `{
 "title": "OpenStack Upgrade in regions EU-DE/EU-NL",
  "impact": 1,
  "message": "Any message why the incident was updated.",
@@ -339,7 +339,7 @@ jsWrongOpenedStatus := `{
  "end_date": "2024-12-11T14:46:03.877Z",
 "type": "incident"
 }`
-jsWrongOpenedStartDate := `{
+	jsWrongOpenedStartDate := `{
  "impact": 1,
  "message": "Any message why the incident was updated.",
  "status": "analysing",
@@ -347,852 +347,852 @@ jsWrongOpenedStartDate := `{
  "start_date": "2024-12-11T14:46:03.877Z",
  "type": "incident"
 }`
-jsWrongOpenedStatusForChangingImpact := `{
+	jsWrongOpenedStatusForChangingImpact := `{
 "impact": 0,
 "message": "Any message why the event was updated.",
 "status": "analysing",
 "update_date": "2024-12-11T14:46:03.877Z",
 "type": "maintenance"
 }`
-jsWrongOpenedMaintenanceImpact := `{
+	jsWrongOpenedMaintenanceImpact := `{
  "impact": 0,
  "message": "Any message why the event was updated.",
  "status": "impact changed",
  "update_date": "2024-12-11T14:46:03.877Z",
  "type": "maintenance"
 }`
-testCases := map[string]*testCase{
-"negative testcase, wrong status for opened incident": {
-JSON:         jsWrongOpenedStatus,
-Expected:     `{"errMsg":"wrong status for incident"}`,
-ExpectedCode: 400,
-},
-"negative testcase, wrong start date for opened incident": {
-JSON:         jsWrongOpenedStartDate,
-Expected:     `{"errMsg":"can not change start date for open incident"}`,
-ExpectedCode: 400,
-},
-"negative testcase, wrong status for changing impact": {
-JSON:         jsWrongOpenedStatusForChangingImpact,
-Expected:     `{"errMsg":"wrong status for changing impact"}`,
-ExpectedCode: 400,
-},
-"negative testcase, can't change impact from incident to maintenance": {
-JSON:         jsWrongOpenedMaintenanceImpact,
-Expected:     `{"errMsg":"can not change impact to 0"}`,
-ExpectedCode: 400,
-},
-}
+	testCases := map[string]*testCase{
+		"negative testcase, wrong status for opened incident": {
+			JSON:         jsWrongOpenedStatus,
+			Expected:     `{"errMsg":"wrong status for incident"}`,
+			ExpectedCode: 400,
+		},
+		"negative testcase, wrong start date for opened incident": {
+			JSON:         jsWrongOpenedStartDate,
+			Expected:     `{"errMsg":"can not change start date for open incident"}`,
+			ExpectedCode: 400,
+		},
+		"negative testcase, wrong status for changing impact": {
+			JSON:         jsWrongOpenedStatusForChangingImpact,
+			Expected:     `{"errMsg":"wrong status for changing impact"}`,
+			ExpectedCode: 400,
+		},
+		"negative testcase, can't change impact from incident to maintenance": {
+			JSON:         jsWrongOpenedMaintenanceImpact,
+			Expected:     `{"errMsg":"can not change impact to 0"}`,
+			ExpectedCode: 400,
+		},
+	}
 
-for testName, c := range testCases {
-t.Logf("start test case: %s\n", testName)
+	for testName, c := range testCases {
+		t.Logf("start test case: %s\n", testName)
 
-url := fmt.Sprintf("/v2/events/%d", incID10)
+		url := fmt.Sprintf("/v2/events/%d", incID10)
 
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(c.JSON))
-r.ServeHTTP(w, req)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(c.JSON))
+		r.ServeHTTP(w, req)
 
-assert.Equal(t, c.ExpectedCode, w.Code)
-assert.Equal(t, c.Expected, w.Body.String())
-}
+		assert.Equal(t, c.ExpectedCode, w.Code)
+		assert.Equal(t, c.Expected, w.Body.String())
+	}
 }
 
 func TestV2PatchEventHandler(t *testing.T) {
-t.Log("start to test incident patching")
-r, _, _ := initTests(t)
+	t.Log("start to test incident patching")
+	r, _, _ := initTests(t)
 
-components := []int{1}
-impact := 1
-title := "Test incident for patching test"
-description := "Test case Patch. Any description for incident"
-startDate := time.Now().AddDate(0, 0, -2).UTC()
-system := false
+	components := []int{1}
+	impact := 1
+	title := "Test incident for patching test"
+	description := "Test case Patch. Any description for incident"
+	startDate := time.Now().AddDate(0, 0, -2).UTC()
+	system := false
 
-internalPatch := func(id int, p *v2.PatchIncidentData) *v2.Incident {
-d, err := json.Marshal(p)
-require.NoError(t, err)
+	internalPatch := func(id int, p *v2.PatchIncidentData) *v2.Incident {
+		d, err := json.Marshal(p)
+		require.NoError(t, err)
 
-url := fmt.Sprintf("/v2/events/%d", id)
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
+		url := fmt.Sprintf("/v2/events/%d", id)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
 
-r.ServeHTTP(w, req)
-assert.Equal(t, 200, w.Code)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, 200, w.Code)
 
-inc := &v2.Incident{}
-err = json.Unmarshal(w.Body.Bytes(), inc)
-require.NoError(t, err)
-return inc
-}
+		inc := &v2.Incident{}
+		err = json.Unmarshal(w.Body.Bytes(), inc)
+		require.NoError(t, err)
+		return inc
+	}
 
-incidentCreateData := v2.IncidentData{
-Title:       title,
-Description: description,
-Impact:      &impact,
-Components:  components,
-StartDate:   startDate,
-System:      &system,
-Type:        event.TypeIncident,
-}
+	incidentCreateData := v2.IncidentData{
+		Title:       title,
+		Description: description,
+		Impact:      &impact,
+		Components:  components,
+		StartDate:   startDate,
+		System:      &system,
+		Type:        event.TypeIncident,
+	}
 
-resp := v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, resp, "v2CreateEvent returned nil")
-incID := resp.Result[0].IncidentID
+	resp := v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, resp, "v2CreateEvent returned nil")
+	incID := resp.Result[0].IncidentID
 
-newTitle := "patched incident title"
-newDescription := "patched incident description"
-t.Logf("patching incident title, from %s to %s", title, newTitle)
+	newTitle := "patched incident title"
+	newDescription := "patched incident description"
+	t.Logf("patching incident title, from %s to %s", title, newTitle)
 
-pData := v2.PatchIncidentData{
-Title:       &newTitle,
-Description: &newDescription,
-Message:     "update title",
-Status:      "analysing",
-UpdateDate:  time.Now().UTC(),
-}
+	pData := v2.PatchIncidentData{
+		Title:       &newTitle,
+		Description: &newDescription,
+		Message:     "update title",
+		Status:      "analysing",
+		UpdateDate:  time.Now().UTC(),
+	}
 
-inc := internalPatch(incID, &pData)
-assert.Equal(t, newTitle, inc.Title)
-assert.Equal(t, newDescription, inc.Description)
+	inc := internalPatch(incID, &pData)
+	assert.Equal(t, newTitle, inc.Title)
+	assert.Equal(t, newDescription, inc.Description)
 
-newImpact := 2
-t.Logf("patching incident impact, from %d to %d", impact, newImpact)
+	newImpact := 2
+	t.Logf("patching incident impact, from %d to %d", impact, newImpact)
 
-pData.Impact = &newImpact
-pData.Status = event.IncidentImpactChanged
+	pData.Impact = &newImpact
+	pData.Status = event.IncidentImpactChanged
 
-inc = internalPatch(incID, &pData)
-assert.Equal(t, newImpact, *inc.Impact)
+	inc = internalPatch(incID, &pData)
+	assert.Equal(t, newImpact, *inc.Impact)
 
-t.Logf("close incident")
-pData.Status = event.IncidentResolved
-updateDate := time.Now().UTC()
-pData.UpdateDate = updateDate
+	t.Logf("close incident")
+	pData.Status = event.IncidentResolved
+	updateDate := time.Now().UTC()
+	pData.UpdateDate = updateDate
 
-inc = internalPatch(incID, &pData)
-require.NotNil(t, inc.EndDate)
-assert.Equal(t, updateDate.Truncate(time.Microsecond), inc.EndDate.Truncate(time.Microsecond))
+	inc = internalPatch(incID, &pData)
+	require.NotNil(t, inc.EndDate)
+	assert.Equal(t, updateDate.Truncate(time.Microsecond), inc.EndDate.Truncate(time.Microsecond))
 
-t.Logf("patching closed incident, change start date and end date")
-startDate = time.Now().AddDate(0, 0, -1).UTC()
-endDate := time.Now().UTC()
+	t.Logf("patching closed incident, change start date and end date")
+	startDate = time.Now().AddDate(0, 0, -1).UTC()
+	endDate := time.Now().UTC()
 
-pData.Status = event.IncidentChanged
-pData.StartDate = &startDate
-pData.EndDate = &endDate
+	pData.Status = event.IncidentChanged
+	pData.StartDate = &startDate
+	pData.EndDate = &endDate
 
-inc = internalPatch(incID, &pData)
-assert.Equal(t, startDate.Truncate(time.Microsecond), inc.StartDate)
-assert.Equal(t, event.IncidentChanged, inc.Status)
-require.NotNil(t, inc.EndDate)
-assert.Equal(t, endDate.Truncate(time.Microsecond), inc.EndDate.Truncate(time.Microsecond))
+	inc = internalPatch(incID, &pData)
+	assert.Equal(t, startDate.Truncate(time.Microsecond), inc.StartDate)
+	assert.Equal(t, event.IncidentChanged, inc.Status)
+	require.NotNil(t, inc.EndDate)
+	assert.Equal(t, endDate.Truncate(time.Microsecond), inc.EndDate.Truncate(time.Microsecond))
 
-t.Logf("reopen closed incident")
+	t.Logf("reopen closed incident")
 
-pData.Status = event.IncidentReopened
-pData.StartDate = nil
-pData.EndDate = nil
-inc = internalPatch(incID, &pData)
-assert.Nil(t, inc.EndDate)
+	pData.Status = event.IncidentReopened
+	pData.StartDate = nil
+	pData.EndDate = nil
+	inc = internalPatch(incID, &pData)
+	assert.Nil(t, inc.EndDate)
 
-t.Logf("final close the test incident")
+	t.Logf("final close the test incident")
 
-pData.Status = event.IncidentResolved
-inc = internalPatch(incID, &pData)
-assert.Equal(t, event.IncidentResolved, inc.Status)
-assert.NotNil(t, inc.EndDate)
+	pData.Status = event.IncidentResolved
+	inc = internalPatch(incID, &pData)
+	assert.Equal(t, event.IncidentResolved, inc.Status)
+	assert.NotNil(t, inc.EndDate)
 }
 
 func TestV2PostEventExtractHandler(t *testing.T) {
-t.Log("start to test component extraction from incident for the endpoint /v2/events/42/extract")
-r, _, _ := initTests(t)
+	t.Log("start to test component extraction from incident for the endpoint /v2/events/42/extract")
+	r, _, _ := initTests(t)
 
-t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
-incidents := v2GetEvents(t, r)
-for _, inc := range incidents {
-if inc.EndDate == nil {
-endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
-inc.EndDate = &endDate
-v2PatchEvent(t, r, inc)
-}
-if inc.Type == event.TypeMaintenance {
-t.Log("the component is maintenance, cancel it")
-v2PatchEvent(t, r, inc, event.MaintenanceCancelled)
-}
-}
+	t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
+	incidents := v2GetEvents(t, r)
+	for _, inc := range incidents {
+		if inc.EndDate == nil {
+			endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
+			inc.EndDate = &endDate
+			v2PatchEvent(t, r, inc)
+		}
+		if inc.Type == event.TypeMaintenance {
+			t.Log("the component is maintenance, cancel it")
+			v2PatchEvent(t, r, inc, event.MaintenanceCancelled)
+		}
+	}
 
-components := []int{1, 2}
-impact := 1
-title := "Test component extraction for component dcs"
-description := "Test incident for extraction"
-startDate := time.Now().AddDate(0, 0, -1).UTC()
-system := false
+	components := []int{1, 2}
+	impact := 1
+	title := "Test component extraction for component dcs"
+	description := "Test incident for extraction"
+	startDate := time.Now().AddDate(0, 0, -1).UTC()
+	system := false
 
-incidentCreateData := v2.IncidentData{
-Title:       title,
-Description: description,
-Impact:      &impact,
-Components:  components,
-StartDate:   startDate,
-System:      &system,
-Type:        event.TypeIncident,
-}
+	incidentCreateData := v2.IncidentData{
+		Title:       title,
+		Description: description,
+		Impact:      &impact,
+		Components:  components,
+		StartDate:   startDate,
+		System:      &system,
+		Type:        event.TypeIncident,
+	}
 
-t.Log("create a initial incident", incidentCreateData)
-result := v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, result, "v2CreateEvent returned nil")
+	t.Log("create a initial incident", incidentCreateData)
+	result := v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, result, "v2CreateEvent returned nil")
 
-t.Logf("prepare to extract components: %d from incident %d", 2, result.Result[0].IncidentID)
-type IncidentData struct {
-Components []int `json:"components"`
-}
-movedComponents := IncidentData{Components: []int{2}}
-data, err := json.Marshal(movedComponents)
-require.NoError(t, err)
+	t.Logf("prepare to extract components: %d from incident %d", 2, result.Result[0].IncidentID)
+	type IncidentData struct {
+		Components []int `json:"components"`
+	}
+	movedComponents := IncidentData{Components: []int{2}}
+	data, err := json.Marshal(movedComponents)
+	require.NoError(t, err)
 
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
-r.ServeHTTP(w, req)
-require.Equal(t, http.StatusOK, w.Code)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
 
-t.Log("check the new incident created by extraction")
-newInc := &v2.Incident{}
-err = json.Unmarshal(w.Body.Bytes(), newInc)
-require.NoError(t, err)
-assert.Len(t, newInc.Components, 1)
-assert.Equal(t, incidentCreateData.Impact, newInc.Impact)
-assert.Equal(t, description, newInc.Description)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test component extraction for component dcs</a>", result.Result[0].IncidentID), newInc.Updates[0].Text)
+	t.Log("check the new incident created by extraction")
+	newInc := &v2.Incident{}
+	err = json.Unmarshal(w.Body.Bytes(), newInc)
+	require.NoError(t, err)
+	assert.Len(t, newInc.Components, 1)
+	assert.Equal(t, incidentCreateData.Impact, newInc.Impact)
+	assert.Equal(t, description, newInc.Description)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test component extraction for component dcs</a>", result.Result[0].IncidentID), newInc.Updates[0].Text)
 
-t.Log("check the old incident with a record about extraction")
-createdInc := v2GetEvent(t, r, result.Result[0].IncidentID)
-assert.Equal(t, "The incident is detected.", createdInc.Updates[0].Text)
-assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test component extraction for component dcs</a>", newInc.ID), createdInc.Updates[1].Text)
+	t.Log("check the old incident with a record about extraction")
+	createdInc := v2GetEvent(t, r, result.Result[0].IncidentID)
+	assert.Equal(t, "The incident is detected.", createdInc.Updates[0].Text)
+	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test component extraction for component dcs</a>", newInc.ID), createdInc.Updates[1].Text)
 
-t.Log("start negative case, try to extract all components from the incident, should return error")
-// start negative case
-movedComponents = IncidentData{Components: []int{1}}
-data, err = json.Marshal(movedComponents)
-require.NoError(t, err)
+	t.Log("start negative case, try to extract all components from the incident, should return error")
+	// start negative case
+	movedComponents = IncidentData{Components: []int{1}}
+	data, err = json.Marshal(movedComponents)
+	require.NoError(t, err)
 
-w = httptest.NewRecorder()
-req, _ = http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
-r.ServeHTTP(w, req)
-require.Equal(t, http.StatusBadRequest, w.Code)
-assert.JSONEq(t, `{"errMsg":"can not move all components to the new incident, keep at least one"}`, w.Body.String())
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.JSONEq(t, `{"errMsg":"can not move all components to the new incident, keep at least one"}`, w.Body.String())
 }
 
 func v2CreateEvent(t *testing.T, r *gin.Engine, inc *v2.IncidentData) *v2.PostIncidentResp {
-t.Helper()
+	t.Helper()
 
-data, err := json.Marshal(inc)
-require.NoError(t, err)
+	data, err := json.Marshal(inc)
+	require.NoError(t, err)
 
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, bytes.NewReader(data))
-r.ServeHTTP(w, req)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, bytes.NewReader(data))
+	r.ServeHTTP(w, req)
 
-if w.Code != http.StatusOK {
-return nil
-}
+	if w.Code != http.StatusOK {
+		return nil
+	}
 
-assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 
-respCreated := &v2.PostIncidentResp{}
-err = json.Unmarshal(w.Body.Bytes(), respCreated)
-require.NoError(t, err)
+	respCreated := &v2.PostIncidentResp{}
+	err = json.Unmarshal(w.Body.Bytes(), respCreated)
+	require.NoError(t, err)
 
-return respCreated
+	return respCreated
 }
 
 func v2GetEvent(t *testing.T, r *gin.Engine, id int) *v2.Incident {
-t.Helper()
-url := fmt.Sprintf("/v2/events/%d", id)
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodGet, url, nil)
+	t.Helper()
+	url := fmt.Sprintf("/v2/events/%d", id)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
 
-r.ServeHTTP(w, req)
+	r.ServeHTTP(w, req)
 
-assert.Equal(t, 200, w.Code)
-var incident v2.Incident
-err := json.Unmarshal(w.Body.Bytes(), &incident)
-require.NoError(t, err)
+	assert.Equal(t, 200, w.Code)
+	var incident v2.Incident
+	err := json.Unmarshal(w.Body.Bytes(), &incident)
+	require.NoError(t, err)
 
-return &incident
+	return &incident
 }
 
 func v2GetEvents(t *testing.T, r *gin.Engine) []*v2.Incident {
-t.Helper()
-url := "/v2/events?limit=50&page=1"
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodGet, url, nil)
+	t.Helper()
+	url := "/v2/events?limit=50&page=1"
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
 
-r.ServeHTTP(w, req)
+	r.ServeHTTP(w, req)
 
-assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 
-// Response now includes pagination
-type response struct {
-Data       []*v2.Incident         `json:"data"`
-Pagination map[string]interface{} `json:"pagination"`
-}
+	// Response now includes pagination
+	type response struct {
+		Data       []*v2.Incident         `json:"data"`
+		Pagination map[string]interface{} `json:"pagination"`
+	}
 
-resp := &response{}
-err := json.Unmarshal(w.Body.Bytes(), resp)
-require.NoError(t, err)
+	resp := &response{}
+	err := json.Unmarshal(w.Body.Bytes(), resp)
+	require.NoError(t, err)
 
-return resp.Data
+	return resp.Data
 }
 
 func v2PatchEvent(t *testing.T, r *gin.Engine, inc *v2.Incident, status ...event.Status) {
-t.Helper()
+	t.Helper()
 
-st := event.IncidentResolved
+	st := event.IncidentResolved
 
-if len(status) == 1 {
-st = status[0]
-}
+	if len(status) == 1 {
+		st = status[0]
+	}
 
-patch := v2.PatchIncidentData{
-Message:    "closed",
-Status:     st,
-UpdateDate: *inc.EndDate,
-}
+	patch := v2.PatchIncidentData{
+		Message:    "closed",
+		Status:     st,
+		UpdateDate: *inc.EndDate,
+	}
 
-d, err := json.Marshal(patch)
-require.NoError(t, err)
+	d, err := json.Marshal(patch)
+	require.NoError(t, err)
 
-url := fmt.Sprintf("/v2/events/%d", inc.ID)
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
+	url := fmt.Sprintf("/v2/events/%d", inc.ID)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
 
-r.ServeHTTP(w, req)
+	r.ServeHTTP(w, req)
 
-assert.Equal(t, 200, w.Code)
+	assert.Equal(t, 200, w.Code)
 }
 
 func TestV2GetEventsFilteredHandler(t *testing.T) { //nolint:gocognit
-t.Log("start to test GET /v2/events with filters and pagination")
-r, _, _ := initTests(t)
+	t.Log("start to test GET /v2/events with filters and pagination")
+	r, _, _ := initTests(t)
 
-// First, get all incidents to understand current state
-allIncidents := v2GetEvents(t, r)
-allIDs := make([]int, len(allIncidents))
-for i, inc := range allIncidents {
-allIDs[i] = inc.ID
-}
-totalCount := len(allIncidents)
-t.Logf("Total incidents in DB: %d, IDs: %v", totalCount, allIDs)
+	// First, get all incidents to understand current state
+	allIncidents := v2GetEvents(t, r)
+	allIDs := make([]int, len(allIncidents))
+	for i, inc := range allIncidents {
+		allIDs[i] = inc.ID
+	}
+	totalCount := len(allIncidents)
+	t.Logf("Total incidents in DB: %d, IDs: %v", totalCount, allIDs)
 
-// Build dynamic expectations based on actual data
-// Incident from dump_test.sql: ID=1, impact=1, system=true, component=1, start_date=2025-05-22
+	// Build dynamic expectations based on actual data
+	// Incident from dump_test.sql: ID=1, impact=1, system=true, component=1, start_date=2025-05-22
 
-// Filter incidents by impact=1
-var impact1IDs []int
-for _, inc := range allIncidents {
-if inc.Impact != nil && *inc.Impact == 1 {
-impact1IDs = append(impact1IDs, inc.ID)
-}
-}
+	// Filter incidents by impact=1
+	var impact1IDs []int
+	for _, inc := range allIncidents {
+		if inc.Impact != nil && *inc.Impact == 1 {
+			impact1IDs = append(impact1IDs, inc.ID)
+		}
+	}
 
-// Filter incidents by impact=2
-var impact2IDs []int
-for _, inc := range allIncidents {
-if inc.Impact != nil && *inc.Impact == 2 {
-impact2IDs = append(impact2IDs, inc.ID)
-}
-}
+	// Filter incidents by impact=2
+	var impact2IDs []int
+	for _, inc := range allIncidents {
+		if inc.Impact != nil && *inc.Impact == 2 {
+			impact2IDs = append(impact2IDs, inc.ID)
+		}
+	}
 
-// Filter incidents by system=true
-var systemTrueIDs []int
-for _, inc := range allIncidents {
-if inc.System != nil && *inc.System {
-systemTrueIDs = append(systemTrueIDs, inc.ID)
-}
-}
+	// Filter incidents by system=true
+	var systemTrueIDs []int
+	for _, inc := range allIncidents {
+		if inc.System != nil && *inc.System {
+			systemTrueIDs = append(systemTrueIDs, inc.ID)
+		}
+	}
 
-// Filter incidents by system=false
-var systemFalseIDs []int
-for _, inc := range allIncidents {
-if inc.System != nil && !*inc.System {
-systemFalseIDs = append(systemFalseIDs, inc.ID)
-}
-}
+	// Filter incidents by system=false
+	var systemFalseIDs []int
+	for _, inc := range allIncidents {
+		if inc.System != nil && !*inc.System {
+			systemFalseIDs = append(systemFalseIDs, inc.ID)
+		}
+	}
 
-type filterTestCase struct {
-name          string
-queryParams   map[string]string
-expectedIDs   []int
-expectedCount int
-}
+	type filterTestCase struct {
+		name          string
+		queryParams   map[string]string
+		expectedIDs   []int
+		expectedCount int
+	}
 
-testCases := []filterTestCase{
-{
-name:          "No filters",
-queryParams:   nil,
-expectedIDs:   allIDs,
-expectedCount: totalCount,
-},
-{
-name:          "Filter by impact minor (1)",
-queryParams:   map[string]string{"impact": "1"},
-expectedIDs:   impact1IDs,
-expectedCount: len(impact1IDs),
-},
-{
-name:          "Filter by impact major (2)",
-queryParams:   map[string]string{"impact": "2"},
-expectedIDs:   impact2IDs,
-expectedCount: len(impact2IDs),
-},
-{
-name:          "Filter by non-existent component_id 99",
-queryParams:   map[string]string{"components": "99"},
-expectedIDs:   []int{},
-expectedCount: 0,
-},
-{
-name:          "Filter by system true",
-queryParams:   map[string]string{"system": "true"},
-expectedIDs:   systemTrueIDs,
-expectedCount: len(systemTrueIDs),
-},
-{
-name:          "Filter by system false",
-queryParams:   map[string]string{"system": "false"},
-expectedIDs:   systemFalseIDs,
-expectedCount: len(systemFalseIDs),
-},
-}
+	testCases := []filterTestCase{
+		{
+			name:          "No filters",
+			queryParams:   nil,
+			expectedIDs:   allIDs,
+			expectedCount: totalCount,
+		},
+		{
+			name:          "Filter by impact minor (1)",
+			queryParams:   map[string]string{"impact": "1"},
+			expectedIDs:   impact1IDs,
+			expectedCount: len(impact1IDs),
+		},
+		{
+			name:          "Filter by impact major (2)",
+			queryParams:   map[string]string{"impact": "2"},
+			expectedIDs:   impact2IDs,
+			expectedCount: len(impact2IDs),
+		},
+		{
+			name:          "Filter by non-existent component_id 99",
+			queryParams:   map[string]string{"components": "99"},
+			expectedIDs:   []int{},
+			expectedCount: 0,
+		},
+		{
+			name:          "Filter by system true",
+			queryParams:   map[string]string{"system": "true"},
+			expectedIDs:   systemTrueIDs,
+			expectedCount: len(systemTrueIDs),
+		},
+		{
+			name:          "Filter by system false",
+			queryParams:   map[string]string{"system": "false"},
+			expectedIDs:   systemFalseIDs,
+			expectedCount: len(systemFalseIDs),
+		},
+	}
 
-for _, tc := range testCases {
-t.Run(tc.name, func(t *testing.T) {
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodGet, v2EventsEndpoint, nil)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, v2EventsEndpoint, nil)
 
-q := req.URL.Query()
-// Add pagination to get all results in one page
-q.Add("limit", "50")
-q.Add("page", "1")
-for k, v := range tc.queryParams {
-q.Add(k, v)
-}
-req.URL.RawQuery = q.Encode()
+			q := req.URL.Query()
+			// Add pagination to get all results in one page
+			q.Add("limit", "50")
+			q.Add("page", "1")
+			for k, v := range tc.queryParams {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
 
-r.ServeHTTP(w, req)
+			r.ServeHTTP(w, req)
 
-assert.Equal(t, http.StatusOK, w.Code, "Unexpected status code for: "+tc.name)
+			assert.Equal(t, http.StatusOK, w.Code, "Unexpected status code for: "+tc.name)
 
-// For paginated events endpoint
-var responseData V2EventsListResponse
-err := json.Unmarshal(w.Body.Bytes(), &responseData)
-require.NoError(t, err, "Failed to unmarshal response for: "+tc.name)
+			// For paginated events endpoint
+			var responseData V2EventsListResponse
+			err := json.Unmarshal(w.Body.Bytes(), &responseData)
+			require.NoError(t, err, "Failed to unmarshal response for: "+tc.name)
 
-actualIncidents := responseData.Data
-assert.Len(t, actualIncidents, tc.expectedCount, "Unexpected number of events for: "+tc.name)
+			actualIncidents := responseData.Data
+			assert.Len(t, actualIncidents, tc.expectedCount, "Unexpected number of events for: "+tc.name)
 
-// Verify pagination metadata exists when there are results
-if tc.expectedCount > 0 {
-require.NotNil(t, responseData.Pagination, "Expected pagination object for: "+tc.name)
-// Verify total records matches expected count
-assert.Equal(t, tc.expectedCount, responseData.Pagination.TotalRecords, "Unexpected total records for: "+tc.name)
-}
+			// Verify pagination metadata exists when there are results
+			if tc.expectedCount > 0 {
+				require.NotNil(t, responseData.Pagination, "Expected pagination object for: "+tc.name)
+				// Verify total records matches expected count
+				assert.Equal(t, tc.expectedCount, responseData.Pagination.TotalRecords, "Unexpected total records for: "+tc.name)
+			}
 
-actualIDs := make([]int, len(actualIncidents))
-for i, inc := range actualIncidents {
-actualIDs[i] = inc.ID
-}
-assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "Unexpected event IDs for: "+tc.name)
-})
-}
+			actualIDs := make([]int, len(actualIncidents))
+			for i, inc := range actualIncidents {
+				actualIDs[i] = inc.ID
+			}
+			assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "Unexpected event IDs for: "+tc.name)
+		})
+	}
 }
 
 func TestV2GetEventsHandler(t *testing.T) {
-t.Logf("start to test GET %s with pagination", v2EventsEndpoint)
-r, _, _ := initTests(t)
+	t.Logf("start to test GET %s with pagination", v2EventsEndpoint)
+	r, _, _ := initTests(t)
 
-type V2EventsListResponseLocal struct {
-Data       []*v2.Incident `json:"data"`
-Pagination struct {
-PageIndex      int `json:"pageIndex"`
-RecordsPerPage int `json:"recordsPerPage"`
-TotalRecords   int `json:"totalRecords"`
-TotalPages     int `json:"totalPages"`
-} `json:"pagination"`
-}
+	type V2EventsListResponseLocal struct {
+		Data       []*v2.Incident `json:"data"`
+		Pagination struct {
+			PageIndex      int `json:"pageIndex"`
+			RecordsPerPage int `json:"recordsPerPage"`
+			TotalRecords   int `json:"totalRecords"`
+			TotalPages     int `json:"totalPages"`
+		} `json:"pagination"`
+	}
 
-// Get all incidents for better debugging from /v2/events endpoint
-allIncidents := v2GetEvents(t, r)
-t.Logf("Initial incidents in DB: %+v", len(allIncidents))
-totalIncidents := len(allIncidents)
-expectedpages := totalIncidents / 10
-if totalIncidents%10 != 0 {
-expectedpages++
-}
+	// Get all incidents for better debugging from /v2/events endpoint
+	allIncidents := v2GetEvents(t, r)
+	t.Logf("Initial incidents in DB: %+v", len(allIncidents))
+	totalIncidents := len(allIncidents)
+	expectedpages := totalIncidents / 10
+	if totalIncidents%10 != 0 {
+		expectedpages++
+	}
 
-testCases := []struct {
-name               string
-queryParams        string
-expectedStatusCode int
-expectedTotal      int
-expectedPages      int
-expectedItemsCount int
-expectedLimit      int
-expectedPage       int
-}{
-{
-name:               "Default pagination",
-queryParams:        "",
-expectedStatusCode: http.StatusOK,
-expectedTotal:      totalIncidents,
-expectedPages:      1,
-expectedItemsCount: totalIncidents,
-expectedLimit:      50, // default limit
-expectedPage:       1,  // default page
-},
-{
-name:               "Pagination with limit 10, page 1",
-queryParams:        "?limit=10&page=1",
-expectedStatusCode: http.StatusOK,
-expectedTotal:      totalIncidents,
-expectedPages:      expectedpages,
-expectedItemsCount: 10,
-expectedLimit:      10,
-expectedPage:       1,
-},
-{
-name:               "Pagination with limit 10, page 2",
-queryParams:        "?limit=10&page=2",
-expectedStatusCode: http.StatusOK,
-expectedTotal:      totalIncidents,
-expectedPages:      expectedpages,
-expectedItemsCount: 10,
-expectedLimit:      10,
-expectedPage:       2,
-},
-{
-name:               "Pagination with limit 20, page 1",
-queryParams:        "?limit=20&page=1",
-expectedStatusCode: http.StatusOK,
-expectedTotal:      totalIncidents,
-expectedPages:      2,
-expectedItemsCount: 20,
-expectedLimit:      20,
-expectedPage:       1,
-},
-}
+	testCases := []struct {
+		name               string
+		queryParams        string
+		expectedStatusCode int
+		expectedTotal      int
+		expectedPages      int
+		expectedItemsCount int
+		expectedLimit      int
+		expectedPage       int
+	}{
+		{
+			name:               "Default pagination",
+			queryParams:        "",
+			expectedStatusCode: http.StatusOK,
+			expectedTotal:      totalIncidents,
+			expectedPages:      1,
+			expectedItemsCount: totalIncidents,
+			expectedLimit:      50, // default limit
+			expectedPage:       1,  // default page
+		},
+		{
+			name:               "Pagination with limit 10, page 1",
+			queryParams:        "?limit=10&page=1",
+			expectedStatusCode: http.StatusOK,
+			expectedTotal:      totalIncidents,
+			expectedPages:      expectedpages,
+			expectedItemsCount: 10,
+			expectedLimit:      10,
+			expectedPage:       1,
+		},
+		{
+			name:               "Pagination with limit 10, page 2",
+			queryParams:        "?limit=10&page=2",
+			expectedStatusCode: http.StatusOK,
+			expectedTotal:      totalIncidents,
+			expectedPages:      expectedpages,
+			expectedItemsCount: 10,
+			expectedLimit:      10,
+			expectedPage:       2,
+		},
+		{
+			name:               "Pagination with limit 20, page 1",
+			queryParams:        "?limit=20&page=1",
+			expectedStatusCode: http.StatusOK,
+			expectedTotal:      totalIncidents,
+			expectedPages:      2,
+			expectedItemsCount: 20,
+			expectedLimit:      20,
+			expectedPage:       1,
+		},
+	}
 
-for _, tc := range testCases {
-t.Run(tc.name, func(t *testing.T) {
-w := httptest.NewRecorder()
-req, _ := http.NewRequest(http.MethodGet, v2EventsEndpoint+tc.queryParams, nil)
-r.ServeHTTP(w, req)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, v2EventsEndpoint+tc.queryParams, nil)
+			r.ServeHTTP(w, req)
 
-assert.Equal(t, tc.expectedStatusCode, w.Code)
+			assert.Equal(t, tc.expectedStatusCode, w.Code)
 
-var response V2EventsListResponseLocal
-err := json.Unmarshal(w.Body.Bytes(), &response)
-require.NoError(t, err)
+			var response V2EventsListResponseLocal
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
 
-assert.Len(t, response.Data, tc.expectedItemsCount)
-assert.Equal(t, tc.expectedTotal, response.Pagination.TotalRecords)
-assert.Equal(t, tc.expectedPages, response.Pagination.TotalPages)
-assert.Equal(t, tc.expectedLimit, response.Pagination.RecordsPerPage)
-assert.Equal(t, tc.expectedPage, response.Pagination.PageIndex)
-})
-}
+			assert.Len(t, response.Data, tc.expectedItemsCount)
+			assert.Equal(t, tc.expectedTotal, response.Pagination.TotalRecords)
+			assert.Equal(t, tc.expectedPages, response.Pagination.TotalPages)
+			assert.Equal(t, tc.expectedLimit, response.Pagination.RecordsPerPage)
+			assert.Equal(t, tc.expectedPage, response.Pagination.PageIndex)
+		})
+	}
 }
 
 func TestV2PostEventsMaintenanceHandler(t *testing.T) {
-t.Log("start to test maintenance creation for /v2/events")
-r, _, _ := initTests(t)
+	t.Log("start to test maintenance creation for /v2/events")
+	r, _, _ := initTests(t)
 
-t.Log("create a maintenance")
+	t.Log("create a maintenance")
 
-components := []int{1, 2}
-impact := 0
-title := "Test maintenance incident for dcs"
-description := "Test maintenance description"
-startDate := time.Now().Add(time.Hour * 1).UTC()
-endDate := time.Now().Add(time.Hour * 2).UTC()
-system := false
+	components := []int{1, 2}
+	impact := 0
+	title := "Test maintenance incident for dcs"
+	description := "Test maintenance description"
+	startDate := time.Now().Add(time.Hour * 1).UTC()
+	endDate := time.Now().Add(time.Hour * 2).UTC()
+	system := false
 
-incidentCreateData := v2.IncidentData{
-Title:       title,
-Description: description,
-Impact:      &impact,
-Components:  components,
-StartDate:   startDate,
-EndDate:     &endDate,
-System:      &system,
-Type:        event.TypeMaintenance,
-}
+	incidentCreateData := v2.IncidentData{
+		Title:       title,
+		Description: description,
+		Impact:      &impact,
+		Components:  components,
+		StartDate:   startDate,
+		EndDate:     &endDate,
+		System:      &system,
+		Type:        event.TypeMaintenance,
+	}
 
-result := v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, result, "v2CreateEvent returned nil")
-assert.Len(t, incidentCreateData.Components, len(result.Result))
+	result := v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, result, "v2CreateEvent returned nil")
+	assert.Len(t, incidentCreateData.Components, len(result.Result))
 
-incident := v2GetEvent(t, r, result.Result[0].IncidentID)
-assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
-assert.Equal(t, incidentCreateData.EndDate.Truncate(time.Microsecond), *incident.EndDate)
-assert.Equal(t, title, incident.Title)
-assert.Equal(t, impact, *incident.Impact)
-assert.Equal(t, system, *incident.System)
-assert.Equal(t, description, incident.Description)
-assert.NotNil(t, incident.Updates)
-assert.Equal(t, event.MaintenancePlanned, incident.Updates[0].Status)
+	incident := v2GetEvent(t, r, result.Result[0].IncidentID)
+	assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
+	assert.Equal(t, incidentCreateData.EndDate.Truncate(time.Microsecond), *incident.EndDate)
+	assert.Equal(t, title, incident.Title)
+	assert.Equal(t, impact, *incident.Impact)
+	assert.Equal(t, system, *incident.System)
+	assert.Equal(t, description, incident.Description)
+	assert.NotNil(t, incident.Updates)
+	assert.Equal(t, event.MaintenancePlanned, incident.Updates[0].Status)
 }
 
 func TestV2PostEventsInfoWithExistingEventsHandler(t *testing.T) {
-t.Log("start to test 'info' incident creation when an 'incident' and a 'maintenance' for the same component already exist")
-r, _, _ := initTests(t)
+	t.Log("start to test 'info' incident creation when an 'incident' and a 'maintenance' for the same component already exist")
+	r, _, _ := initTests(t)
 
-// 1. Preparation: Close any existing open incidents for a clean state.
-incidentsBeforeTest := v2GetEvents(t, r)
-for _, inc := range incidentsBeforeTest {
-if inc.EndDate == nil {
-t.Logf("Closing pre-existing open incident ID: %d for test setup", inc.ID)
-endDate := inc.StartDate.Add(time.Hour * 1).UTC()
-inc.EndDate = &endDate
-v2PatchEvent(t, r, inc)
-}
-}
+	// 1. Preparation: Close any existing open incidents for a clean state.
+	incidentsBeforeTest := v2GetEvents(t, r)
+	for _, inc := range incidentsBeforeTest {
+		if inc.EndDate == nil {
+			t.Logf("Closing pre-existing open incident ID: %d for test setup", inc.ID)
+			endDate := inc.StartDate.Add(time.Hour * 1).UTC()
+			inc.EndDate = &endDate
+			v2PatchEvent(t, r, inc)
+		}
+	}
 
-// 2. Create an active "incident" type event.
-t.Log("Create an active 'incident' type event")
-incidentComponentID := 1
-initialIncidentImpact := 1
-initialIncidentTitle := "Initial incident event"
-initialIncidentDescription := "Description for the initial incident"
-initialIncidentStartDate := time.Now().AddDate(0, 0, -1).UTC()
-initialIncidentSystem := false
+	// 2. Create an active "incident" type event.
+	t.Log("Create an active 'incident' type event")
+	incidentComponentID := 1
+	initialIncidentImpact := 1
+	initialIncidentTitle := "Initial incident event"
+	initialIncidentDescription := "Description for the initial incident"
+	initialIncidentStartDate := time.Now().AddDate(0, 0, -1).UTC()
+	initialIncidentSystem := false
 
-initialIncidentData := v2.IncidentData{
-Title:       initialIncidentTitle,
-Description: initialIncidentDescription,
-Impact:      &initialIncidentImpact,
-Components:  []int{incidentComponentID},
-StartDate:   initialIncidentStartDate,
-System:      &initialIncidentSystem,
-Type:        event.TypeIncident,
-}
+	initialIncidentData := v2.IncidentData{
+		Title:       initialIncidentTitle,
+		Description: initialIncidentDescription,
+		Impact:      &initialIncidentImpact,
+		Components:  []int{incidentComponentID},
+		StartDate:   initialIncidentStartDate,
+		System:      &initialIncidentSystem,
+		Type:        event.TypeIncident,
+	}
 
-initialIncidentResp := v2CreateEvent(t, r, &initialIncidentData)
-require.NotNil(t, initialIncidentResp, "Failed to create initial incident")
-require.Len(t, initialIncidentResp.Result, 1, "Initial incident response should have one result")
-initialIncidentID := initialIncidentResp.Result[0].IncidentID
-t.Logf("Created active 'incident' with ID: %d for component %d", initialIncidentID, incidentComponentID)
+	initialIncidentResp := v2CreateEvent(t, r, &initialIncidentData)
+	require.NotNil(t, initialIncidentResp, "Failed to create initial incident")
+	require.Len(t, initialIncidentResp.Result, 1, "Initial incident response should have one result")
+	initialIncidentID := initialIncidentResp.Result[0].IncidentID
+	t.Logf("Created active 'incident' with ID: %d for component %d", initialIncidentID, incidentComponentID)
 
-// 3. Create a planned "maintenance" type event for the SAME component.
-t.Log("Step 3: Create a planned 'maintenance' type event for the same component")
-maintenanceImpact := 0 // Maintenance impact is typically 0
-maintenanceTitle := "Planned Maintenance for Component"
-maintenanceDescription := "Description for the maintenance event"
-maintenanceStartDate := time.Now().AddDate(0, 0, 7).UTC()
-maintenanceEndDate := time.Now().AddDate(0, 0, 7).Add(time.Hour * 2).UTC()
-maintenanceSystem := false
+	// 3. Create a planned "maintenance" type event for the SAME component.
+	t.Log("Step 3: Create a planned 'maintenance' type event for the same component")
+	maintenanceImpact := 0 // Maintenance impact is typically 0
+	maintenanceTitle := "Planned Maintenance for Component"
+	maintenanceDescription := "Description for the maintenance event"
+	maintenanceStartDate := time.Now().AddDate(0, 0, 7).UTC()
+	maintenanceEndDate := time.Now().AddDate(0, 0, 7).Add(time.Hour * 2).UTC()
+	maintenanceSystem := false
 
-maintenanceIncidentData := v2.IncidentData{
-Title:       maintenanceTitle,
-Description: maintenanceDescription,
-Impact:      &maintenanceImpact,
-Components:  []int{incidentComponentID},
-StartDate:   maintenanceStartDate,
-EndDate:     &maintenanceEndDate,
-System:      &maintenanceSystem,
-Type:        "maintenance",
-}
+	maintenanceIncidentData := v2.IncidentData{
+		Title:       maintenanceTitle,
+		Description: maintenanceDescription,
+		Impact:      &maintenanceImpact,
+		Components:  []int{incidentComponentID},
+		StartDate:   maintenanceStartDate,
+		EndDate:     &maintenanceEndDate,
+		System:      &maintenanceSystem,
+		Type:        "maintenance",
+	}
 
-maintenanceIncidentResp := v2CreateEvent(t, r, &maintenanceIncidentData)
-require.NotNil(t, maintenanceIncidentResp, "Failed to create 'maintenance' incident")
-require.Len(t, maintenanceIncidentResp.Result, 1, "'Maintenance' incident response should have one result")
-maintenanceIncidentID := maintenanceIncidentResp.Result[0].IncidentID
-t.Logf("Created planned 'maintenance' with ID: %d for component %d, starting at %s", maintenanceIncidentID, incidentComponentID, maintenanceStartDate)
+	maintenanceIncidentResp := v2CreateEvent(t, r, &maintenanceIncidentData)
+	require.NotNil(t, maintenanceIncidentResp, "Failed to create 'maintenance' incident")
+	require.Len(t, maintenanceIncidentResp.Result, 1, "'Maintenance' incident response should have one result")
+	maintenanceIncidentID := maintenanceIncidentResp.Result[0].IncidentID
+	t.Logf("Created planned 'maintenance' with ID: %d for component %d, starting at %s", maintenanceIncidentID, incidentComponentID, maintenanceStartDate)
 
-// 4. Create a new "info" type event for the SAME component.
-t.Log("Step 4: Create a new 'info' type event for the same component")
-infoImpact := 0
-infoTitle := "Informational Update During IsActive Incident and Before Maintenance"
-infoDescription := "Description for the info event"
-infoStartDate := time.Now().Add(time.Minute * -30).UTC()
-infoEndDate := time.Now().Add(time.Minute * 30).UTC()
-infoSystem := false
+	// 4. Create a new "info" type event for the SAME component.
+	t.Log("Step 4: Create a new 'info' type event for the same component")
+	infoImpact := 0
+	infoTitle := "Informational Update During IsActive Incident and Before Maintenance"
+	infoDescription := "Description for the info event"
+	infoStartDate := time.Now().Add(time.Minute * -30).UTC()
+	infoEndDate := time.Now().Add(time.Minute * 30).UTC()
+	infoSystem := false
 
-infoIncidentData := v2.IncidentData{
-Title:       infoTitle,
-Description: infoDescription,
-Impact:      &infoImpact,
-Components:  []int{incidentComponentID},
-StartDate:   infoStartDate,
-EndDate:     &infoEndDate,
-System:      &infoSystem,
-Type:        "info",
-}
+	infoIncidentData := v2.IncidentData{
+		Title:       infoTitle,
+		Description: infoDescription,
+		Impact:      &infoImpact,
+		Components:  []int{incidentComponentID},
+		StartDate:   infoStartDate,
+		EndDate:     &infoEndDate,
+		System:      &infoSystem,
+		Type:        "info",
+	}
 
-infoIncidentResp := v2CreateEvent(t, r, &infoIncidentData)
-require.NotNil(t, infoIncidentResp, "Failed to create 'info' incident")
-require.Len(t, infoIncidentResp.Result, 1, "'Info' incident response should have one result")
-infoIncidentID := infoIncidentResp.Result[0].IncidentID
-t.Logf("Created 'info' incident with ID: %d for component %d", infoIncidentID, incidentComponentID)
+	infoIncidentResp := v2CreateEvent(t, r, &infoIncidentData)
+	require.NotNil(t, infoIncidentResp, "Failed to create 'info' incident")
+	require.Len(t, infoIncidentResp.Result, 1, "'Info' incident response should have one result")
+	infoIncidentID := infoIncidentResp.Result[0].IncidentID
+	t.Logf("Created 'info' incident with ID: %d for component %d", infoIncidentID, incidentComponentID)
 
-// Assertions.
-t.Log("Step 5: Perform assertions")
-assert.NotEqual(t, initialIncidentID, infoIncidentID, "Info incident should have a new, distinct ID")
-assert.NotEqual(t, maintenanceIncidentID, infoIncidentID, "Info incident should have a new, distinct ID from maintenance")
+	// Assertions.
+	t.Log("Step 5: Perform assertions")
+	assert.NotEqual(t, initialIncidentID, infoIncidentID, "Info incident should have a new, distinct ID")
+	assert.NotEqual(t, maintenanceIncidentID, infoIncidentID, "Info incident should have a new, distinct ID from maintenance")
 
-// Verify the 'info' incident.
-fetchedInfoIncident := v2GetEvent(t, r, infoIncidentID)
-assert.Equal(t, infoTitle, fetchedInfoIncident.Title)
-assert.Equal(t, infoDescription, fetchedInfoIncident.Description)
-assert.Equal(t, event.TypeInformation, fetchedInfoIncident.Type)
-assert.Equal(t, infoImpact, *fetchedInfoIncident.Impact)
-assert.Contains(t, fetchedInfoIncident.Components, incidentComponentID)
-require.NotNil(t, fetchedInfoIncident.EndDate)
-assert.True(t, infoEndDate.Truncate(time.Second).Equal(fetchedInfoIncident.EndDate.Truncate(time.Second)))
+	// Verify the 'info' incident.
+	fetchedInfoIncident := v2GetEvent(t, r, infoIncidentID)
+	assert.Equal(t, infoTitle, fetchedInfoIncident.Title)
+	assert.Equal(t, infoDescription, fetchedInfoIncident.Description)
+	assert.Equal(t, event.TypeInformation, fetchedInfoIncident.Type)
+	assert.Equal(t, infoImpact, *fetchedInfoIncident.Impact)
+	assert.Contains(t, fetchedInfoIncident.Components, incidentComponentID)
+	require.NotNil(t, fetchedInfoIncident.EndDate)
+	assert.True(t, infoEndDate.Truncate(time.Second).Equal(fetchedInfoIncident.EndDate.Truncate(time.Second)))
 
-// Verify the initial 'incident' event is still open.
-fetchedInitialIncident := v2GetEvent(t, r, initialIncidentID)
-assert.Equal(t, initialIncidentTitle, fetchedInitialIncident.Title)
-assert.Equal(t, initialIncidentDescription, fetchedInitialIncident.Description)
-assert.Equal(t, event.TypeIncident, fetchedInitialIncident.Type)
-assert.Nil(t, fetchedInitialIncident.EndDate, "Initial 'incident' event should still be open")
-assert.Contains(t, fetchedInitialIncident.Components, incidentComponentID, "Initial 'incident' should still have its component")
-assert.Len(t, fetchedInitialIncident.Components, 1, "Initial 'incident' should only have its original component")
+	// Verify the initial 'incident' event is still open.
+	fetchedInitialIncident := v2GetEvent(t, r, initialIncidentID)
+	assert.Equal(t, initialIncidentTitle, fetchedInitialIncident.Title)
+	assert.Equal(t, initialIncidentDescription, fetchedInitialIncident.Description)
+	assert.Equal(t, event.TypeIncident, fetchedInitialIncident.Type)
+	assert.Nil(t, fetchedInitialIncident.EndDate, "Initial 'incident' event should still be open")
+	assert.Contains(t, fetchedInitialIncident.Components, incidentComponentID, "Initial 'incident' should still have its component")
+	assert.Len(t, fetchedInitialIncident.Components, 1, "Initial 'incident' should only have its original component")
 
-// Verify the planned 'maintenance' event is still scheduled.
-fetchedMaintenanceIncident := v2GetEvent(t, r, maintenanceIncidentID)
-assert.Equal(t, maintenanceTitle, fetchedMaintenanceIncident.Title)
-assert.Equal(t, maintenanceDescription, fetchedMaintenanceIncident.Description)
-assert.Equal(t, event.TypeMaintenance, fetchedMaintenanceIncident.Type)
-require.NotNil(t, fetchedMaintenanceIncident.EndDate, "Maintenance event should have an end date")
-assert.True(t, maintenanceEndDate.Truncate(time.Second).Equal(fetchedMaintenanceIncident.EndDate.Truncate(time.Second)), "Maintenance end date mismatch")
-assert.Contains(t, fetchedMaintenanceIncident.Components, incidentComponentID, "Maintenance event should still have its component")
-assert.Len(t, fetchedMaintenanceIncident.Components, 1, "Maintenance event should only have its original component")
+	// Verify the planned 'maintenance' event is still scheduled.
+	fetchedMaintenanceIncident := v2GetEvent(t, r, maintenanceIncidentID)
+	assert.Equal(t, maintenanceTitle, fetchedMaintenanceIncident.Title)
+	assert.Equal(t, maintenanceDescription, fetchedMaintenanceIncident.Description)
+	assert.Equal(t, event.TypeMaintenance, fetchedMaintenanceIncident.Type)
+	require.NotNil(t, fetchedMaintenanceIncident.EndDate, "Maintenance event should have an end date")
+	assert.True(t, maintenanceEndDate.Truncate(time.Second).Equal(fetchedMaintenanceIncident.EndDate.Truncate(time.Second)), "Maintenance end date mismatch")
+	assert.Contains(t, fetchedMaintenanceIncident.Components, incidentComponentID, "Maintenance event should still have its component")
+	assert.Len(t, fetchedMaintenanceIncident.Components, 1, "Maintenance event should only have its original component")
 }
 
 func TestV2PatchEventUpdateHandler(t *testing.T) {
-t.Log("start to test PATCH /v2/events/:incidentID/updates/:updateID")
-r, _, _ := initTests(t)
+	t.Log("start to test PATCH /v2/events/:incidentID/updates/:updateID")
+	r, _, _ := initTests(t)
 
-// Clean up database before test to ensure a clean state for this test case.
-truncateIncidents(t)
+	// Clean up database before test to ensure a clean state for this test case.
+	truncateIncidents(t)
 
-components := []int{1}
-impact := 1
-title := "Incident for testing update patch"
-startDate := time.Now().UTC()
-system := false
-incidentCreateData := v2.IncidentData{
-Title:      title,
-Impact:     &impact,
-Components: components,
-StartDate:  startDate,
-System:     &system,
-Type:       event.TypeIncident,
-}
+	components := []int{1}
+	impact := 1
+	title := "Incident for testing update patch"
+	startDate := time.Now().UTC()
+	system := false
+	incidentCreateData := v2.IncidentData{
+		Title:      title,
+		Impact:     &impact,
+		Components: components,
+		StartDate:  startDate,
+		System:     &system,
+		Type:       event.TypeIncident,
+	}
 
-createResp := v2CreateEvent(t, r, &incidentCreateData)
-require.NotNil(t, createResp, "Failed to create incident for test")
-require.Len(t, createResp.Result, 1)
-incidentID := createResp.Result[0].IncidentID
+	createResp := v2CreateEvent(t, r, &incidentCreateData)
+	require.NotNil(t, createResp, "Failed to create incident for test")
+	require.Len(t, createResp.Result, 1)
+	incidentID := createResp.Result[0].IncidentID
 
-// The created incident has one update with index 0
-initialIncident := v2GetEvent(t, r, incidentID)
-require.Len(t, initialIncident.Updates, 1)
+	// The created incident has one update with index 0
+	initialIncident := v2GetEvent(t, r, incidentID)
+	require.Len(t, initialIncident.Updates, 1)
 
-testCases := []struct {
-name           string
-incidentID     int
-updateIndex    int
-body           string
-expectedStatus int
-expectedBody   string
-checkResponse  func(t *testing.T, body []byte)
-}{
-{
-name:           "Successful update",
-incidentID:     incidentID,
-updateIndex:    0,
-body:           `{"text": "The text of this update has been successfully changed."}`,
-expectedStatus: http.StatusOK,
-checkResponse: func(t *testing.T, body []byte) {
-var update v2.EventUpdateData
-err := json.Unmarshal(body, &update)
-require.NoError(t, err)
-assert.Equal(t, 0, update.ID)
-assert.Equal(t, "The text of this update has been successfully changed.", update.Text)
-assert.Equal(t, event.IncidentDetected, update.Status)
-},
-},
-{
-name:           "Incident not found",
-incidentID:     99999,
-updateIndex:    0,
-body:           `{"text": "This should fail."}`,
-expectedStatus: http.StatusNotFound,
-expectedBody:   `{"errMsg":"incident not found"}`,
-},
-{
-name:           "Update index not found",
-incidentID:     incidentID,
-updateIndex:    99,
-body:           `{"text": "This should also fail."}`,
-expectedStatus: http.StatusNotFound,
-expectedBody:   `{"errMsg":"update not found"}`,
-},
-{
-name:           "Invalid update index (negative)",
-incidentID:     incidentID,
-updateIndex:    -1,
-body:           `{"text": "This should also fail."}`,
-expectedStatus: http.StatusBadRequest,
-expectedBody:   (`{"errMsg":"Key: 'updateData.UpdateID' Error:Field validation for 'UpdateID' failed on the 'gte' tag"}`),
-},
-{
-name:           "Empty text in body",
-incidentID:     incidentID,
-updateIndex:    0,
-body:           `{"text": ""}`,
-expectedStatus: http.StatusBadRequest,
-expectedBody:   (`{"errMsg":"Key: 'PatchEventUpdateData.Text' Error:Field validation for 'Text' failed on the 'required' tag"}`),
-},
-{
-name:           "Missing text field in body",
-incidentID:     incidentID,
-updateIndex:    0,
-body:           `{}`,
-expectedStatus: http.StatusBadRequest,
-expectedBody:   (`{"errMsg":"Key: 'PatchEventUpdateData.Text' Error:Field validation for 'Text' failed on the 'required' tag"}`),
-},
-{
-name:           "ff",
-incidentID:     incidentID,
-updateIndex:    0,
-body:           `{"text": "invalid json`,
-expectedStatus: http.StatusBadRequest,
-expectedBody:   `{"errMsg":"unexpected EOF"}`,
-},
-}
+	testCases := []struct {
+		name           string
+		incidentID     int
+		updateIndex    int
+		body           string
+		expectedStatus int
+		expectedBody   string
+		checkResponse  func(t *testing.T, body []byte)
+	}{
+		{
+			name:           "Successful update",
+			incidentID:     incidentID,
+			updateIndex:    0,
+			body:           `{"text": "The text of this update has been successfully changed."}`,
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body []byte) {
+				var update v2.EventUpdateData
+				err := json.Unmarshal(body, &update)
+				require.NoError(t, err)
+				assert.Equal(t, 0, update.ID)
+				assert.Equal(t, "The text of this update has been successfully changed.", update.Text)
+				assert.Equal(t, event.IncidentDetected, update.Status)
+			},
+		},
+		{
+			name:           "Incident not found",
+			incidentID:     99999,
+			updateIndex:    0,
+			body:           `{"text": "This should fail."}`,
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   `{"errMsg":"incident not found"}`,
+		},
+		{
+			name:           "Update index not found",
+			incidentID:     incidentID,
+			updateIndex:    99,
+			body:           `{"text": "This should also fail."}`,
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   `{"errMsg":"update not found"}`,
+		},
+		{
+			name:           "Invalid update index (negative)",
+			incidentID:     incidentID,
+			updateIndex:    -1,
+			body:           `{"text": "This should also fail."}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   (`{"errMsg":"Key: 'updateData.UpdateID' Error:Field validation for 'UpdateID' failed on the 'gte' tag"}`),
+		},
+		{
+			name:           "Empty text in body",
+			incidentID:     incidentID,
+			updateIndex:    0,
+			body:           `{"text": ""}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   (`{"errMsg":"Key: 'PatchEventUpdateData.Text' Error:Field validation for 'Text' failed on the 'required' tag"}`),
+		},
+		{
+			name:           "Missing text field in body",
+			incidentID:     incidentID,
+			updateIndex:    0,
+			body:           `{}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   (`{"errMsg":"Key: 'PatchEventUpdateData.Text' Error:Field validation for 'Text' failed on the 'required' tag"}`),
+		},
+		{
+			name:           "ff",
+			incidentID:     incidentID,
+			updateIndex:    0,
+			body:           `{"text": "invalid json`,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"errMsg":"unexpected EOF"}`,
+		},
+	}
 
-for _, tc := range testCases {
-t.Run(tc.name, func(t *testing.T) {
-url := fmt.Sprintf("/v2/events/%d/updates/%d", tc.incidentID, tc.updateIndex)
-req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(tc.body))
-req.Header.Set("Content-Type", "application/json")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			url := fmt.Sprintf("/v2/events/%d/updates/%d", tc.incidentID, tc.updateIndex)
+			req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
 
-w := httptest.NewRecorder()
-r.ServeHTTP(w, req)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
 
-assert.Equal(t, tc.expectedStatus, w.Code)
+			assert.Equal(t, tc.expectedStatus, w.Code)
 
-if tc.checkResponse != nil {
-tc.checkResponse(t, w.Body.Bytes())
-}
+			if tc.checkResponse != nil {
+				tc.checkResponse(t, w.Body.Bytes())
+			}
 
-if tc.expectedBody != "" {
-assert.JSONEq(t, tc.expectedBody, w.Body.String())
-}
-})
-}
+			if tc.expectedBody != "" {
+				assert.JSONEq(t, tc.expectedBody, w.Body.String())
+			}
+		})
+	}
 }

--- a/tests/v2_events_test.go
+++ b/tests/v2_events_test.go
@@ -1,0 +1,1198 @@
+package tests
+
+import (
+"bytes"
+"encoding/json"
+"fmt"
+"net/http"
+"net/http/httptest"
+"strings"
+"testing"
+"time"
+
+"github.com/gin-gonic/gin"
+"github.com/stretchr/testify/assert"
+"github.com/stretchr/testify/require"
+
+v2 "github.com/stackmon/otc-status-dashboard/internal/api/v2"
+"github.com/stackmon/otc-status-dashboard/internal/event"
+)
+
+// V2EventsListResponse defines the expected structure for the GET /v2/events endpoint.
+type V2EventsListResponse struct {
+Data       []*v2.Incident `json:"data"`
+Message    string         `json:"message,omitempty"`
+Pagination *struct {
+PageIndex      int `json:"pageIndex"`
+RecordsPerPage int `json:"recordsPerPage"`
+TotalRecords   int `json:"totalRecords"`
+TotalPages     int `json:"totalPages"`
+} `json:"pagination,omitempty"`
+}
+
+func TestV2PostEventsHandlerNegative(t *testing.T) {
+t.Log("start to test incident creation and check json data for /v2/events")
+r, _, _ := initTests(t)
+
+type testCase struct {
+ExpectedCode int
+Expected     string
+JSON         string
+}
+
+jsEndPresent := `{
+  "title":"OpenStack Upgrade in regions EU-DE/EU-NL",
+  "impact":1,
+  "components":[
+    1
+  ],
+  "start_date":"2024-11-25T09:32:14.075Z",
+  "end_date":"2024-11-25T09:32:14.075Z",
+  "system":false,
+  "type":"incident",
+  "updates":[
+    {
+      "id":163,
+      "status":"resolved",
+      "text":"issue resolved",
+      "timestamp":"2024-11-25T09:32:14.075Z"
+    }
+  ]
+}`
+jsUpdatesPresent := `{
+  "title":"OpenStack Upgrade in regions EU-DE/EU-NL",
+  "impact":1,
+  "components":[
+    1
+  ],
+  "start_date":"2024-11-25T09:32:14.075Z",
+  "system":false,
+  "type":"incident",
+  "updates":[
+    {
+      "id":163,
+      "status":"resolved",
+      "text":"issue resolved",
+      "timestamp":"2024-11-25T09:32:14.075Z"
+    }
+  ]
+}`
+jsWrongComponents := `{
+  "title":"OpenStack Upgrade in regions EU-DE/EU-NL",
+  "impact":1,
+  "components":[
+    218,
+    254
+  ],
+  "start_date":"2024-11-25T09:32:14.075Z",
+  "system":false,
+  "type":"incident"
+}`
+jsWrongMaintenanceImpact := `{
+  "title":"Maintenance with wrong impact",
+  "impact":1,
+  "components":[1],
+  "start_date":"2024-11-25T09:32:14.075Z",
+  "system":false,
+  "type":"maintenance"
+}`
+
+jsWrongIncidentImpact := `{
+  "title":"event with maintenance impact",
+  "impact":0,
+  "components":[1],
+  "start_date":"2024-11-25T09:32:14.075Z",
+  "system":false,
+  "type":"incident"
+}`
+
+testCases := map[string]*testCase{
+"negative testcase, event is not a maintenance and end_date is present": {
+JSON:         jsEndPresent,
+Expected:     `{"errMsg":"event end_date should be empty"}`,
+ExpectedCode: 400,
+},
+"negative testcase, updates are present": {
+JSON:         jsUpdatesPresent,
+Expected:     `{"errMsg":"event updates should be empty"}`,
+ExpectedCode: 400,
+},
+"negative testcase, wrong components ids": {
+JSON:         jsWrongComponents,
+Expected:     `{"errMsg":"component does not exist, component_id: 218"}`,
+ExpectedCode: 400,
+},
+"negative testcase, maintenance with non-zero impact": {
+JSON:         jsWrongMaintenanceImpact,
+Expected:     `{"errMsg":"impact must be 0 for type 'maintenance' or 'info' and gt 0 for 'incident'"}`,
+ExpectedCode: 400,
+},
+"negative testcase, event with zero impact": {
+JSON:         jsWrongIncidentImpact,
+Expected:     `{"errMsg":"impact must be 0 for type 'maintenance' or 'info' and gt 0 for 'incident'"}`,
+ExpectedCode: 400,
+},
+}
+
+for title, c := range testCases {
+t.Logf("start test case: %s\n", title)
+
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, strings.NewReader(c.JSON))
+r.ServeHTTP(w, req)
+
+assert.Equal(t, c.ExpectedCode, w.Code)
+assert.Equal(t, c.Expected, w.Body.String())
+}
+}
+
+func TestV2PostEventsHandler(t *testing.T) {
+t.Log("start to test incident creation for /v2/events")
+r, _, _ := initTests(t)
+
+t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
+incidents := v2GetEvents(t, r)
+for _, inc := range incidents {
+if inc.EndDate == nil {
+endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
+inc.EndDate = &endDate
+v2PatchEvent(t, r, inc)
+}
+if inc.Type == event.TypeMaintenance {
+t.Log("the component is maintenance, cancel it")
+v2PatchEvent(t, r, inc, event.MaintenanceCancelled)
+}
+}
+
+components := []int{1, 2}
+impact := 1
+title := "Test incident creation for api V2 for components: 1, 2. Test 1."
+description := "any description for incident"
+startDate := time.Now().AddDate(0, 0, -1).UTC()
+system := false
+incType := event.TypeIncident
+
+incidentCreateData := v2.IncidentData{
+Title:       title,
+Description: description,
+Impact:      &impact,
+Components:  components,
+StartDate:   startDate,
+System:      &system,
+Type:        incType,
+}
+
+result := v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, result, "v2CreateEvent returned nil")
+
+assert.Len(t, result.Result, len(incidentCreateData.Components))
+assert.Empty(t, result.Result[0].Error)
+assert.Empty(t, result.Result[1].Error)
+assert.Equal(t, len(incidents)+1, result.Result[0].IncidentID)
+assert.Equal(t, len(incidents)+1, result.Result[1].IncidentID)
+
+t.Log("check created incident data, incident id: ", result.Result[0].IncidentID)
+incident := v2GetEvent(t, r, result.Result[0].IncidentID)
+assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
+assert.Equal(t, title, incident.Title)
+assert.Equal(t, impact, *incident.Impact)
+assert.Equal(t, system, *incident.System)
+assert.Nil(t, incident.EndDate)
+require.NotNil(t, incident.Type)
+assert.Equal(t, event.TypeIncident, incident.Type)
+require.NotNil(t, incident.Updates)
+assert.Equal(t, "The incident is detected.", incident.Updates[0].Text)
+
+t.Log("create a new incident with the same components and the same impact, should close previous and move components to the new")
+t.Log("current time:", time.Now().UTC())
+incidentCreateData.Title = "Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new."
+result = v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, result, "v2CreateEvent returned nil")
+assert.Equal(t, len(incidents)+2, result.Result[0].IncidentID)
+assert.Equal(t, len(incidents)+2, result.Result[1].IncidentID)
+
+oldIncident := v2GetEvent(t, r, result.Result[0].IncidentID-1)
+assert.NotNil(t, oldIncident.EndDate)
+assert.Len(t, oldIncident.Components, 1)
+assert.NotNil(t, oldIncident.Updates)
+assert.Len(t, oldIncident.Updates, 3)
+t.Logf("STATUS updates: %v", oldIncident.Updates)
+assert.Equal(t, event.IncidentDetected, oldIncident.Updates[0].Status)
+assert.Equal(t, event.OutDatedSystem, oldIncident.Updates[1].Status)
+assert.Equal(t, event.IncidentResolved, oldIncident.Updates[2].Status)
+assert.Equal(t, "The incident is detected.", oldIncident.Updates[0].Text)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>", result.Result[0].IncidentID), oldIncident.Updates[1].Text)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>, Incident closed by system", result.Result[0].IncidentID), oldIncident.Updates[2].Text)
+
+incidentN3 := v2GetEvent(t, r, result.Result[0].IncidentID)
+assert.Nil(t, incidentN3.EndDate)
+assert.Len(t, incidentN3.Components, 2)
+assert.NotNil(t, incidentN3.Updates)
+assert.Len(t, incidentN3.Updates, 3)
+assert.Equal(t, event.IncidentDetected, incidentN3.Updates[0].Status)
+assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
+assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[2].Status)
+assert.Equal(t, "The incident is detected.", incidentN3.Updates[0].Text)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", result.Result[0].IncidentID-1), incidentN3.Updates[1].Text)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", result.Result[0].IncidentID-1), incidentN3.Updates[2].Text)
+
+t.Log("create a new maintenance with the same components and higher impact, should create a new without components")
+
+impact = 0
+title = "Test maintenance creation for api V2 for the components: 1-Cloud Container Engine (Container, EU-DE, cce), 2-Cloud Container Engine (Container, EU-NL, cce)"
+incidentCreateData.Title = title
+incidentCreateData.Description = "any description for maintenance incident"
+endDate := time.Now().AddDate(0, 0, 1).UTC()
+incidentCreateData.EndDate = &endDate
+incidentCreateData.Type = event.TypeMaintenance
+
+result = v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, result, "v2CreateEvent returned nil")
+assert.Equal(t, len(incidents)+3, result.Result[0].IncidentID)
+assert.Equal(t, len(incidents)+3, result.Result[1].IncidentID)
+
+maintenanceIncident := v2GetEvent(t, r, result.Result[0].IncidentID)
+assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), maintenanceIncident.StartDate)
+require.NotNil(t, incidentCreateData.EndDate)
+require.NotNil(t, maintenanceIncident.EndDate)
+assert.Equal(t, incidentCreateData.EndDate.Truncate(time.Microsecond), maintenanceIncident.EndDate.Truncate(time.Microsecond))
+assert.Equal(t, title, maintenanceIncident.Title)
+assert.Equal(t, impact, *maintenanceIncident.Impact)
+assert.Equal(t, system, *maintenanceIncident.System)
+assert.Equal(t, incidentCreateData.Description, maintenanceIncident.Description)
+assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
+require.NotNil(t, maintenanceIncident.Type)
+assert.Equal(t, event.TypeMaintenance, maintenanceIncident.Type)
+assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
+
+incidentN3 = v2GetEvent(t, r, result.Result[0].IncidentID-1)
+assert.Nil(t, incidentN3.EndDate)
+assert.Len(t, incidentN3.Components, 2)
+assert.NotNil(t, incidentN3.Updates)
+assert.Len(t, incidentN3.Updates, 3)
+assert.Equal(t, event.IncidentDetected, incidentN3.Updates[0].Status)
+assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
+assert.Equal(t, event.OutDatedSystem, incidentN3.Updates[1].Status)
+assert.Equal(t, "The incident is detected.", incidentN3.Updates[0].Text)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", incidentN3.ID-1), incidentN3.Updates[1].Text)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test 1.</a>", incidentN3.ID-1), incidentN3.Updates[2].Text)
+require.NotNil(t, incidentN3.Type)
+assert.Equal(t, event.TypeIncident, incidentN3.Type)
+
+t.Log("check response, if incident component is not present in the opened incidents, should create a new incident")
+components = []int{3}
+impact = 1
+incidentCreateData = v2.IncidentData{
+Title:       "Test for another different component id: 3.",
+Description: "Any description for incident with different component",
+Impact:      &impact,
+Components:  components,
+StartDate:   startDate,
+System:      &system,
+Type:        event.TypeIncident,
+}
+result = v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, result, "v2CreateEvent returned nil")
+// ID should be incidentN3.ID + 2 (maintenance + this new incident)
+expectedID := incidentN3.ID + 2
+assert.Equal(t, expectedID, result.Result[0].IncidentID)
+assert.Equal(t, 3, result.Result[0].ComponentID)
+}
+
+func TestV2PatchEventHandlerNegative(t *testing.T) {
+t.Log("start to test negative cases for incident patching and check json data for /v2/events/42")
+r, _, _ := initTests(t)
+
+components := []int{1}
+impact := 1
+title := "Incident for negative tests for incident patching"
+startDate := time.Now().AddDate(0, 0, -1).UTC()
+system := false
+
+incidentCreateData := v2.IncidentData{
+Title:       title,
+Description: "any description for incident",
+Impact:      &impact,
+Components:  components,
+StartDate:   startDate,
+System:      &system,
+Type:        event.TypeIncident,
+}
+
+resp := v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, resp, "v2CreateEvent returned nil")
+incID10 := resp.Result[0].IncidentID
+
+type testCase struct {
+ExpectedCode int
+Expected     string
+JSON         string
+}
+
+jsWrongOpenedStatus := `{
+"title": "OpenStack Upgrade in regions EU-DE/EU-NL",
+ "impact": 1,
+ "message": "Any message why the incident was updated.",
+ "status": "in progress",
+ "update_date": "2024-12-11T14:46:03.877Z",
+ "start_date": "2024-12-11T14:46:03.877Z",
+ "end_date": "2024-12-11T14:46:03.877Z",
+"type": "incident"
+}`
+jsWrongOpenedStartDate := `{
+ "impact": 1,
+ "message": "Any message why the incident was updated.",
+ "status": "analysing",
+ "update_date": "2024-12-11T14:46:03.877Z",
+ "start_date": "2024-12-11T14:46:03.877Z",
+ "type": "incident"
+}`
+jsWrongOpenedStatusForChangingImpact := `{
+"impact": 0,
+"message": "Any message why the event was updated.",
+"status": "analysing",
+"update_date": "2024-12-11T14:46:03.877Z",
+"type": "maintenance"
+}`
+jsWrongOpenedMaintenanceImpact := `{
+ "impact": 0,
+ "message": "Any message why the event was updated.",
+ "status": "impact changed",
+ "update_date": "2024-12-11T14:46:03.877Z",
+ "type": "maintenance"
+}`
+testCases := map[string]*testCase{
+"negative testcase, wrong status for opened incident": {
+JSON:         jsWrongOpenedStatus,
+Expected:     `{"errMsg":"wrong status for incident"}`,
+ExpectedCode: 400,
+},
+"negative testcase, wrong start date for opened incident": {
+JSON:         jsWrongOpenedStartDate,
+Expected:     `{"errMsg":"can not change start date for open incident"}`,
+ExpectedCode: 400,
+},
+"negative testcase, wrong status for changing impact": {
+JSON:         jsWrongOpenedStatusForChangingImpact,
+Expected:     `{"errMsg":"wrong status for changing impact"}`,
+ExpectedCode: 400,
+},
+"negative testcase, can't change impact from incident to maintenance": {
+JSON:         jsWrongOpenedMaintenanceImpact,
+Expected:     `{"errMsg":"can not change impact to 0"}`,
+ExpectedCode: 400,
+},
+}
+
+for testName, c := range testCases {
+t.Logf("start test case: %s\n", testName)
+
+url := fmt.Sprintf("/v2/events/%d", incID10)
+
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(c.JSON))
+r.ServeHTTP(w, req)
+
+assert.Equal(t, c.ExpectedCode, w.Code)
+assert.Equal(t, c.Expected, w.Body.String())
+}
+}
+
+func TestV2PatchEventHandler(t *testing.T) {
+t.Log("start to test incident patching")
+r, _, _ := initTests(t)
+
+components := []int{1}
+impact := 1
+title := "Test incident for patching test"
+description := "Test case Patch. Any description for incident"
+startDate := time.Now().AddDate(0, 0, -2).UTC()
+system := false
+
+internalPatch := func(id int, p *v2.PatchIncidentData) *v2.Incident {
+d, err := json.Marshal(p)
+require.NoError(t, err)
+
+url := fmt.Sprintf("/v2/events/%d", id)
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
+
+r.ServeHTTP(w, req)
+assert.Equal(t, 200, w.Code)
+
+inc := &v2.Incident{}
+err = json.Unmarshal(w.Body.Bytes(), inc)
+require.NoError(t, err)
+return inc
+}
+
+incidentCreateData := v2.IncidentData{
+Title:       title,
+Description: description,
+Impact:      &impact,
+Components:  components,
+StartDate:   startDate,
+System:      &system,
+Type:        event.TypeIncident,
+}
+
+resp := v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, resp, "v2CreateEvent returned nil")
+incID := resp.Result[0].IncidentID
+
+newTitle := "patched incident title"
+newDescription := "patched incident description"
+t.Logf("patching incident title, from %s to %s", title, newTitle)
+
+pData := v2.PatchIncidentData{
+Title:       &newTitle,
+Description: &newDescription,
+Message:     "update title",
+Status:      "analysing",
+UpdateDate:  time.Now().UTC(),
+}
+
+inc := internalPatch(incID, &pData)
+assert.Equal(t, newTitle, inc.Title)
+assert.Equal(t, newDescription, inc.Description)
+
+newImpact := 2
+t.Logf("patching incident impact, from %d to %d", impact, newImpact)
+
+pData.Impact = &newImpact
+pData.Status = event.IncidentImpactChanged
+
+inc = internalPatch(incID, &pData)
+assert.Equal(t, newImpact, *inc.Impact)
+
+t.Logf("close incident")
+pData.Status = event.IncidentResolved
+updateDate := time.Now().UTC()
+pData.UpdateDate = updateDate
+
+inc = internalPatch(incID, &pData)
+require.NotNil(t, inc.EndDate)
+assert.Equal(t, updateDate.Truncate(time.Microsecond), inc.EndDate.Truncate(time.Microsecond))
+
+t.Logf("patching closed incident, change start date and end date")
+startDate = time.Now().AddDate(0, 0, -1).UTC()
+endDate := time.Now().UTC()
+
+pData.Status = event.IncidentChanged
+pData.StartDate = &startDate
+pData.EndDate = &endDate
+
+inc = internalPatch(incID, &pData)
+assert.Equal(t, startDate.Truncate(time.Microsecond), inc.StartDate)
+assert.Equal(t, event.IncidentChanged, inc.Status)
+require.NotNil(t, inc.EndDate)
+assert.Equal(t, endDate.Truncate(time.Microsecond), inc.EndDate.Truncate(time.Microsecond))
+
+t.Logf("reopen closed incident")
+
+pData.Status = event.IncidentReopened
+pData.StartDate = nil
+pData.EndDate = nil
+inc = internalPatch(incID, &pData)
+assert.Nil(t, inc.EndDate)
+
+t.Logf("final close the test incident")
+
+pData.Status = event.IncidentResolved
+inc = internalPatch(incID, &pData)
+assert.Equal(t, event.IncidentResolved, inc.Status)
+assert.NotNil(t, inc.EndDate)
+}
+
+func TestV2PostEventExtractHandler(t *testing.T) {
+t.Log("start to test component extraction from incident for the endpoint /v2/events/42/extract")
+r, _, _ := initTests(t)
+
+t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
+incidents := v2GetEvents(t, r)
+for _, inc := range incidents {
+if inc.EndDate == nil {
+endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
+inc.EndDate = &endDate
+v2PatchEvent(t, r, inc)
+}
+if inc.Type == event.TypeMaintenance {
+t.Log("the component is maintenance, cancel it")
+v2PatchEvent(t, r, inc, event.MaintenanceCancelled)
+}
+}
+
+components := []int{1, 2}
+impact := 1
+title := "Test component extraction for component dcs"
+description := "Test incident for extraction"
+startDate := time.Now().AddDate(0, 0, -1).UTC()
+system := false
+
+incidentCreateData := v2.IncidentData{
+Title:       title,
+Description: description,
+Impact:      &impact,
+Components:  components,
+StartDate:   startDate,
+System:      &system,
+Type:        event.TypeIncident,
+}
+
+t.Log("create a initial incident", incidentCreateData)
+result := v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, result, "v2CreateEvent returned nil")
+
+t.Logf("prepare to extract components: %d from incident %d", 2, result.Result[0].IncidentID)
+type IncidentData struct {
+Components []int `json:"components"`
+}
+movedComponents := IncidentData{Components: []int{2}}
+data, err := json.Marshal(movedComponents)
+require.NoError(t, err)
+
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
+r.ServeHTTP(w, req)
+require.Equal(t, http.StatusOK, w.Code)
+
+t.Log("check the new incident created by extraction")
+newInc := &v2.Incident{}
+err = json.Unmarshal(w.Body.Bytes(), newInc)
+require.NoError(t, err)
+assert.Len(t, newInc.Components, 1)
+assert.Equal(t, incidentCreateData.Impact, newInc.Impact)
+assert.Equal(t, description, newInc.Description)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test component extraction for component dcs</a>", result.Result[0].IncidentID), newInc.Updates[0].Text)
+
+t.Log("check the old incident with a record about extraction")
+createdInc := v2GetEvent(t, r, result.Result[0].IncidentID)
+assert.Equal(t, "The incident is detected.", createdInc.Updates[0].Text)
+assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test component extraction for component dcs</a>", newInc.ID), createdInc.Updates[1].Text)
+
+t.Log("start negative case, try to extract all components from the incident, should return error")
+// start negative case
+movedComponents = IncidentData{Components: []int{1}}
+data, err = json.Marshal(movedComponents)
+require.NoError(t, err)
+
+w = httptest.NewRecorder()
+req, _ = http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
+r.ServeHTTP(w, req)
+require.Equal(t, http.StatusBadRequest, w.Code)
+assert.JSONEq(t, `{"errMsg":"can not move all components to the new incident, keep at least one"}`, w.Body.String())
+}
+
+func v2CreateEvent(t *testing.T, r *gin.Engine, inc *v2.IncidentData) *v2.PostIncidentResp {
+t.Helper()
+
+data, err := json.Marshal(inc)
+require.NoError(t, err)
+
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, bytes.NewReader(data))
+r.ServeHTTP(w, req)
+
+if w.Code != http.StatusOK {
+return nil
+}
+
+assert.Equal(t, http.StatusOK, w.Code)
+
+respCreated := &v2.PostIncidentResp{}
+err = json.Unmarshal(w.Body.Bytes(), respCreated)
+require.NoError(t, err)
+
+return respCreated
+}
+
+func v2GetEvent(t *testing.T, r *gin.Engine, id int) *v2.Incident {
+t.Helper()
+url := fmt.Sprintf("/v2/events/%d", id)
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodGet, url, nil)
+
+r.ServeHTTP(w, req)
+
+assert.Equal(t, 200, w.Code)
+var incident v2.Incident
+err := json.Unmarshal(w.Body.Bytes(), &incident)
+require.NoError(t, err)
+
+return &incident
+}
+
+func v2GetEvents(t *testing.T, r *gin.Engine) []*v2.Incident {
+t.Helper()
+url := "/v2/events?limit=50&page=1"
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodGet, url, nil)
+
+r.ServeHTTP(w, req)
+
+assert.Equal(t, http.StatusOK, w.Code)
+
+// Response now includes pagination
+type response struct {
+Data       []*v2.Incident         `json:"data"`
+Pagination map[string]interface{} `json:"pagination"`
+}
+
+resp := &response{}
+err := json.Unmarshal(w.Body.Bytes(), resp)
+require.NoError(t, err)
+
+return resp.Data
+}
+
+func v2PatchEvent(t *testing.T, r *gin.Engine, inc *v2.Incident, status ...event.Status) {
+t.Helper()
+
+st := event.IncidentResolved
+
+if len(status) == 1 {
+st = status[0]
+}
+
+patch := v2.PatchIncidentData{
+Message:    "closed",
+Status:     st,
+UpdateDate: *inc.EndDate,
+}
+
+d, err := json.Marshal(patch)
+require.NoError(t, err)
+
+url := fmt.Sprintf("/v2/events/%d", inc.ID)
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
+
+r.ServeHTTP(w, req)
+
+assert.Equal(t, 200, w.Code)
+}
+
+func TestV2GetEventsFilteredHandler(t *testing.T) { //nolint:gocognit
+t.Log("start to test GET /v2/events with filters and pagination")
+r, _, _ := initTests(t)
+
+// First, get all incidents to understand current state
+allIncidents := v2GetEvents(t, r)
+allIDs := make([]int, len(allIncidents))
+for i, inc := range allIncidents {
+allIDs[i] = inc.ID
+}
+totalCount := len(allIncidents)
+t.Logf("Total incidents in DB: %d, IDs: %v", totalCount, allIDs)
+
+// Build dynamic expectations based on actual data
+// Incident from dump_test.sql: ID=1, impact=1, system=true, component=1, start_date=2025-05-22
+
+// Filter incidents by impact=1
+var impact1IDs []int
+for _, inc := range allIncidents {
+if inc.Impact != nil && *inc.Impact == 1 {
+impact1IDs = append(impact1IDs, inc.ID)
+}
+}
+
+// Filter incidents by impact=2
+var impact2IDs []int
+for _, inc := range allIncidents {
+if inc.Impact != nil && *inc.Impact == 2 {
+impact2IDs = append(impact2IDs, inc.ID)
+}
+}
+
+// Filter incidents by system=true
+var systemTrueIDs []int
+for _, inc := range allIncidents {
+if inc.System != nil && *inc.System {
+systemTrueIDs = append(systemTrueIDs, inc.ID)
+}
+}
+
+// Filter incidents by system=false
+var systemFalseIDs []int
+for _, inc := range allIncidents {
+if inc.System != nil && !*inc.System {
+systemFalseIDs = append(systemFalseIDs, inc.ID)
+}
+}
+
+type filterTestCase struct {
+name          string
+queryParams   map[string]string
+expectedIDs   []int
+expectedCount int
+}
+
+testCases := []filterTestCase{
+{
+name:          "No filters",
+queryParams:   nil,
+expectedIDs:   allIDs,
+expectedCount: totalCount,
+},
+{
+name:          "Filter by impact minor (1)",
+queryParams:   map[string]string{"impact": "1"},
+expectedIDs:   impact1IDs,
+expectedCount: len(impact1IDs),
+},
+{
+name:          "Filter by impact major (2)",
+queryParams:   map[string]string{"impact": "2"},
+expectedIDs:   impact2IDs,
+expectedCount: len(impact2IDs),
+},
+{
+name:          "Filter by non-existent component_id 99",
+queryParams:   map[string]string{"components": "99"},
+expectedIDs:   []int{},
+expectedCount: 0,
+},
+{
+name:          "Filter by system true",
+queryParams:   map[string]string{"system": "true"},
+expectedIDs:   systemTrueIDs,
+expectedCount: len(systemTrueIDs),
+},
+{
+name:          "Filter by system false",
+queryParams:   map[string]string{"system": "false"},
+expectedIDs:   systemFalseIDs,
+expectedCount: len(systemFalseIDs),
+},
+}
+
+for _, tc := range testCases {
+t.Run(tc.name, func(t *testing.T) {
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodGet, v2EventsEndpoint, nil)
+
+q := req.URL.Query()
+// Add pagination to get all results in one page
+q.Add("limit", "50")
+q.Add("page", "1")
+for k, v := range tc.queryParams {
+q.Add(k, v)
+}
+req.URL.RawQuery = q.Encode()
+
+r.ServeHTTP(w, req)
+
+assert.Equal(t, http.StatusOK, w.Code, "Unexpected status code for: "+tc.name)
+
+// For paginated events endpoint
+var responseData V2EventsListResponse
+err := json.Unmarshal(w.Body.Bytes(), &responseData)
+require.NoError(t, err, "Failed to unmarshal response for: "+tc.name)
+
+actualIncidents := responseData.Data
+assert.Len(t, actualIncidents, tc.expectedCount, "Unexpected number of events for: "+tc.name)
+
+// Verify pagination metadata exists when there are results
+if tc.expectedCount > 0 {
+require.NotNil(t, responseData.Pagination, "Expected pagination object for: "+tc.name)
+// Verify total records matches expected count
+assert.Equal(t, tc.expectedCount, responseData.Pagination.TotalRecords, "Unexpected total records for: "+tc.name)
+}
+
+actualIDs := make([]int, len(actualIncidents))
+for i, inc := range actualIncidents {
+actualIDs[i] = inc.ID
+}
+assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "Unexpected event IDs for: "+tc.name)
+})
+}
+}
+
+func TestV2GetEventsHandler(t *testing.T) {
+t.Logf("start to test GET %s with pagination", v2EventsEndpoint)
+r, _, _ := initTests(t)
+
+type V2EventsListResponseLocal struct {
+Data       []*v2.Incident `json:"data"`
+Pagination struct {
+PageIndex      int `json:"pageIndex"`
+RecordsPerPage int `json:"recordsPerPage"`
+TotalRecords   int `json:"totalRecords"`
+TotalPages     int `json:"totalPages"`
+} `json:"pagination"`
+}
+
+// Get all incidents for better debugging from /v2/events endpoint
+allIncidents := v2GetEvents(t, r)
+t.Logf("Initial incidents in DB: %+v", len(allIncidents))
+totalIncidents := len(allIncidents)
+expectedpages := totalIncidents / 10
+if totalIncidents%10 != 0 {
+expectedpages++
+}
+
+testCases := []struct {
+name               string
+queryParams        string
+expectedStatusCode int
+expectedTotal      int
+expectedPages      int
+expectedItemsCount int
+expectedLimit      int
+expectedPage       int
+}{
+{
+name:               "Default pagination",
+queryParams:        "",
+expectedStatusCode: http.StatusOK,
+expectedTotal:      totalIncidents,
+expectedPages:      1,
+expectedItemsCount: totalIncidents,
+expectedLimit:      50, // default limit
+expectedPage:       1,  // default page
+},
+{
+name:               "Pagination with limit 10, page 1",
+queryParams:        "?limit=10&page=1",
+expectedStatusCode: http.StatusOK,
+expectedTotal:      totalIncidents,
+expectedPages:      expectedpages,
+expectedItemsCount: 10,
+expectedLimit:      10,
+expectedPage:       1,
+},
+{
+name:               "Pagination with limit 10, page 2",
+queryParams:        "?limit=10&page=2",
+expectedStatusCode: http.StatusOK,
+expectedTotal:      totalIncidents,
+expectedPages:      expectedpages,
+expectedItemsCount: 10,
+expectedLimit:      10,
+expectedPage:       2,
+},
+{
+name:               "Pagination with limit 20, page 1",
+queryParams:        "?limit=20&page=1",
+expectedStatusCode: http.StatusOK,
+expectedTotal:      totalIncidents,
+expectedPages:      2,
+expectedItemsCount: 20,
+expectedLimit:      20,
+expectedPage:       1,
+},
+}
+
+for _, tc := range testCases {
+t.Run(tc.name, func(t *testing.T) {
+w := httptest.NewRecorder()
+req, _ := http.NewRequest(http.MethodGet, v2EventsEndpoint+tc.queryParams, nil)
+r.ServeHTTP(w, req)
+
+assert.Equal(t, tc.expectedStatusCode, w.Code)
+
+var response V2EventsListResponseLocal
+err := json.Unmarshal(w.Body.Bytes(), &response)
+require.NoError(t, err)
+
+assert.Len(t, response.Data, tc.expectedItemsCount)
+assert.Equal(t, tc.expectedTotal, response.Pagination.TotalRecords)
+assert.Equal(t, tc.expectedPages, response.Pagination.TotalPages)
+assert.Equal(t, tc.expectedLimit, response.Pagination.RecordsPerPage)
+assert.Equal(t, tc.expectedPage, response.Pagination.PageIndex)
+})
+}
+}
+
+func TestV2PostEventsMaintenanceHandler(t *testing.T) {
+t.Log("start to test maintenance creation for /v2/events")
+r, _, _ := initTests(t)
+
+t.Log("create a maintenance")
+
+components := []int{1, 2}
+impact := 0
+title := "Test maintenance incident for dcs"
+description := "Test maintenance description"
+startDate := time.Now().Add(time.Hour * 1).UTC()
+endDate := time.Now().Add(time.Hour * 2).UTC()
+system := false
+
+incidentCreateData := v2.IncidentData{
+Title:       title,
+Description: description,
+Impact:      &impact,
+Components:  components,
+StartDate:   startDate,
+EndDate:     &endDate,
+System:      &system,
+Type:        event.TypeMaintenance,
+}
+
+result := v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, result, "v2CreateEvent returned nil")
+assert.Len(t, incidentCreateData.Components, len(result.Result))
+
+incident := v2GetEvent(t, r, result.Result[0].IncidentID)
+assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
+assert.Equal(t, incidentCreateData.EndDate.Truncate(time.Microsecond), *incident.EndDate)
+assert.Equal(t, title, incident.Title)
+assert.Equal(t, impact, *incident.Impact)
+assert.Equal(t, system, *incident.System)
+assert.Equal(t, description, incident.Description)
+assert.NotNil(t, incident.Updates)
+assert.Equal(t, event.MaintenancePlanned, incident.Updates[0].Status)
+}
+
+func TestV2PostEventsInfoWithExistingEventsHandler(t *testing.T) {
+t.Log("start to test 'info' incident creation when an 'incident' and a 'maintenance' for the same component already exist")
+r, _, _ := initTests(t)
+
+// 1. Preparation: Close any existing open incidents for a clean state.
+incidentsBeforeTest := v2GetEvents(t, r)
+for _, inc := range incidentsBeforeTest {
+if inc.EndDate == nil {
+t.Logf("Closing pre-existing open incident ID: %d for test setup", inc.ID)
+endDate := inc.StartDate.Add(time.Hour * 1).UTC()
+inc.EndDate = &endDate
+v2PatchEvent(t, r, inc)
+}
+}
+
+// 2. Create an active "incident" type event.
+t.Log("Create an active 'incident' type event")
+incidentComponentID := 1
+initialIncidentImpact := 1
+initialIncidentTitle := "Initial incident event"
+initialIncidentDescription := "Description for the initial incident"
+initialIncidentStartDate := time.Now().AddDate(0, 0, -1).UTC()
+initialIncidentSystem := false
+
+initialIncidentData := v2.IncidentData{
+Title:       initialIncidentTitle,
+Description: initialIncidentDescription,
+Impact:      &initialIncidentImpact,
+Components:  []int{incidentComponentID},
+StartDate:   initialIncidentStartDate,
+System:      &initialIncidentSystem,
+Type:        event.TypeIncident,
+}
+
+initialIncidentResp := v2CreateEvent(t, r, &initialIncidentData)
+require.NotNil(t, initialIncidentResp, "Failed to create initial incident")
+require.Len(t, initialIncidentResp.Result, 1, "Initial incident response should have one result")
+initialIncidentID := initialIncidentResp.Result[0].IncidentID
+t.Logf("Created active 'incident' with ID: %d for component %d", initialIncidentID, incidentComponentID)
+
+// 3. Create a planned "maintenance" type event for the SAME component.
+t.Log("Step 3: Create a planned 'maintenance' type event for the same component")
+maintenanceImpact := 0 // Maintenance impact is typically 0
+maintenanceTitle := "Planned Maintenance for Component"
+maintenanceDescription := "Description for the maintenance event"
+maintenanceStartDate := time.Now().AddDate(0, 0, 7).UTC()
+maintenanceEndDate := time.Now().AddDate(0, 0, 7).Add(time.Hour * 2).UTC()
+maintenanceSystem := false
+
+maintenanceIncidentData := v2.IncidentData{
+Title:       maintenanceTitle,
+Description: maintenanceDescription,
+Impact:      &maintenanceImpact,
+Components:  []int{incidentComponentID},
+StartDate:   maintenanceStartDate,
+EndDate:     &maintenanceEndDate,
+System:      &maintenanceSystem,
+Type:        "maintenance",
+}
+
+maintenanceIncidentResp := v2CreateEvent(t, r, &maintenanceIncidentData)
+require.NotNil(t, maintenanceIncidentResp, "Failed to create 'maintenance' incident")
+require.Len(t, maintenanceIncidentResp.Result, 1, "'Maintenance' incident response should have one result")
+maintenanceIncidentID := maintenanceIncidentResp.Result[0].IncidentID
+t.Logf("Created planned 'maintenance' with ID: %d for component %d, starting at %s", maintenanceIncidentID, incidentComponentID, maintenanceStartDate)
+
+// 4. Create a new "info" type event for the SAME component.
+t.Log("Step 4: Create a new 'info' type event for the same component")
+infoImpact := 0
+infoTitle := "Informational Update During IsActive Incident and Before Maintenance"
+infoDescription := "Description for the info event"
+infoStartDate := time.Now().Add(time.Minute * -30).UTC()
+infoEndDate := time.Now().Add(time.Minute * 30).UTC()
+infoSystem := false
+
+infoIncidentData := v2.IncidentData{
+Title:       infoTitle,
+Description: infoDescription,
+Impact:      &infoImpact,
+Components:  []int{incidentComponentID},
+StartDate:   infoStartDate,
+EndDate:     &infoEndDate,
+System:      &infoSystem,
+Type:        "info",
+}
+
+infoIncidentResp := v2CreateEvent(t, r, &infoIncidentData)
+require.NotNil(t, infoIncidentResp, "Failed to create 'info' incident")
+require.Len(t, infoIncidentResp.Result, 1, "'Info' incident response should have one result")
+infoIncidentID := infoIncidentResp.Result[0].IncidentID
+t.Logf("Created 'info' incident with ID: %d for component %d", infoIncidentID, incidentComponentID)
+
+// Assertions.
+t.Log("Step 5: Perform assertions")
+assert.NotEqual(t, initialIncidentID, infoIncidentID, "Info incident should have a new, distinct ID")
+assert.NotEqual(t, maintenanceIncidentID, infoIncidentID, "Info incident should have a new, distinct ID from maintenance")
+
+// Verify the 'info' incident.
+fetchedInfoIncident := v2GetEvent(t, r, infoIncidentID)
+assert.Equal(t, infoTitle, fetchedInfoIncident.Title)
+assert.Equal(t, infoDescription, fetchedInfoIncident.Description)
+assert.Equal(t, event.TypeInformation, fetchedInfoIncident.Type)
+assert.Equal(t, infoImpact, *fetchedInfoIncident.Impact)
+assert.Contains(t, fetchedInfoIncident.Components, incidentComponentID)
+require.NotNil(t, fetchedInfoIncident.EndDate)
+assert.True(t, infoEndDate.Truncate(time.Second).Equal(fetchedInfoIncident.EndDate.Truncate(time.Second)))
+
+// Verify the initial 'incident' event is still open.
+fetchedInitialIncident := v2GetEvent(t, r, initialIncidentID)
+assert.Equal(t, initialIncidentTitle, fetchedInitialIncident.Title)
+assert.Equal(t, initialIncidentDescription, fetchedInitialIncident.Description)
+assert.Equal(t, event.TypeIncident, fetchedInitialIncident.Type)
+assert.Nil(t, fetchedInitialIncident.EndDate, "Initial 'incident' event should still be open")
+assert.Contains(t, fetchedInitialIncident.Components, incidentComponentID, "Initial 'incident' should still have its component")
+assert.Len(t, fetchedInitialIncident.Components, 1, "Initial 'incident' should only have its original component")
+
+// Verify the planned 'maintenance' event is still scheduled.
+fetchedMaintenanceIncident := v2GetEvent(t, r, maintenanceIncidentID)
+assert.Equal(t, maintenanceTitle, fetchedMaintenanceIncident.Title)
+assert.Equal(t, maintenanceDescription, fetchedMaintenanceIncident.Description)
+assert.Equal(t, event.TypeMaintenance, fetchedMaintenanceIncident.Type)
+require.NotNil(t, fetchedMaintenanceIncident.EndDate, "Maintenance event should have an end date")
+assert.True(t, maintenanceEndDate.Truncate(time.Second).Equal(fetchedMaintenanceIncident.EndDate.Truncate(time.Second)), "Maintenance end date mismatch")
+assert.Contains(t, fetchedMaintenanceIncident.Components, incidentComponentID, "Maintenance event should still have its component")
+assert.Len(t, fetchedMaintenanceIncident.Components, 1, "Maintenance event should only have its original component")
+}
+
+func TestV2PatchEventUpdateHandler(t *testing.T) {
+t.Log("start to test PATCH /v2/events/:incidentID/updates/:updateID")
+r, _, _ := initTests(t)
+
+// Clean up database before test to ensure a clean state for this test case.
+truncateIncidents(t)
+
+components := []int{1}
+impact := 1
+title := "Incident for testing update patch"
+startDate := time.Now().UTC()
+system := false
+incidentCreateData := v2.IncidentData{
+Title:      title,
+Impact:     &impact,
+Components: components,
+StartDate:  startDate,
+System:     &system,
+Type:       event.TypeIncident,
+}
+
+createResp := v2CreateEvent(t, r, &incidentCreateData)
+require.NotNil(t, createResp, "Failed to create incident for test")
+require.Len(t, createResp.Result, 1)
+incidentID := createResp.Result[0].IncidentID
+
+// The created incident has one update with index 0
+initialIncident := v2GetEvent(t, r, incidentID)
+require.Len(t, initialIncident.Updates, 1)
+
+testCases := []struct {
+name           string
+incidentID     int
+updateIndex    int
+body           string
+expectedStatus int
+expectedBody   string
+checkResponse  func(t *testing.T, body []byte)
+}{
+{
+name:           "Successful update",
+incidentID:     incidentID,
+updateIndex:    0,
+body:           `{"text": "The text of this update has been successfully changed."}`,
+expectedStatus: http.StatusOK,
+checkResponse: func(t *testing.T, body []byte) {
+var update v2.EventUpdateData
+err := json.Unmarshal(body, &update)
+require.NoError(t, err)
+assert.Equal(t, 0, update.ID)
+assert.Equal(t, "The text of this update has been successfully changed.", update.Text)
+assert.Equal(t, event.IncidentDetected, update.Status)
+},
+},
+{
+name:           "Incident not found",
+incidentID:     99999,
+updateIndex:    0,
+body:           `{"text": "This should fail."}`,
+expectedStatus: http.StatusNotFound,
+expectedBody:   `{"errMsg":"incident not found"}`,
+},
+{
+name:           "Update index not found",
+incidentID:     incidentID,
+updateIndex:    99,
+body:           `{"text": "This should also fail."}`,
+expectedStatus: http.StatusNotFound,
+expectedBody:   `{"errMsg":"update not found"}`,
+},
+{
+name:           "Invalid update index (negative)",
+incidentID:     incidentID,
+updateIndex:    -1,
+body:           `{"text": "This should also fail."}`,
+expectedStatus: http.StatusBadRequest,
+expectedBody:   (`{"errMsg":"Key: 'updateData.UpdateID' Error:Field validation for 'UpdateID' failed on the 'gte' tag"}`),
+},
+{
+name:           "Empty text in body",
+incidentID:     incidentID,
+updateIndex:    0,
+body:           `{"text": ""}`,
+expectedStatus: http.StatusBadRequest,
+expectedBody:   (`{"errMsg":"Key: 'PatchEventUpdateData.Text' Error:Field validation for 'Text' failed on the 'required' tag"}`),
+},
+{
+name:           "Missing text field in body",
+incidentID:     incidentID,
+updateIndex:    0,
+body:           `{}`,
+expectedStatus: http.StatusBadRequest,
+expectedBody:   (`{"errMsg":"Key: 'PatchEventUpdateData.Text' Error:Field validation for 'Text' failed on the 'required' tag"}`),
+},
+{
+name:           "ff",
+incidentID:     incidentID,
+updateIndex:    0,
+body:           `{"text": "invalid json`,
+expectedStatus: http.StatusBadRequest,
+expectedBody:   `{"errMsg":"unexpected EOF"}`,
+},
+}
+
+for _, tc := range testCases {
+t.Run(tc.name, func(t *testing.T) {
+url := fmt.Sprintf("/v2/events/%d/updates/%d", tc.incidentID, tc.updateIndex)
+req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(tc.body))
+req.Header.Set("Content-Type", "application/json")
+
+w := httptest.NewRecorder()
+r.ServeHTTP(w, req)
+
+assert.Equal(t, tc.expectedStatus, w.Code)
+
+if tc.checkResponse != nil {
+tc.checkResponse(t, w.Body.Bytes())
+}
+
+if tc.expectedBody != "" {
+assert.JSONEq(t, tc.expectedBody, w.Body.String())
+}
+})
+}
+}

--- a/tests/v2_system_incident_test.go
+++ b/tests/v2_system_incident_test.go
@@ -141,7 +141,7 @@ func TestV2SystemIncidentCreationNoActiveEvents(t *testing.T) {
 	assert.NotZero(t, result.IncidentID)
 
 	// Verify the created incident
-	incident := v2GetIncident(t, r, result.IncidentID)
+	incident := v2GetEvent(t, r, result.IncidentID)
 	assert.Equal(t, incData.Title, incident.Title)
 	assert.Equal(t, impact, *incident.Impact)
 	assert.True(t, *incident.System)
@@ -250,7 +250,7 @@ func TestV2SystemIncidentCreationWithNonSystemIncident(t *testing.T) {
 	assert.Empty(t, result.Error)
 
 	// Verify no new incident was created
-	incident := v2GetIncident(t, r, result.IncidentID)
+	incident := v2GetEvent(t, r, result.IncidentID)
 	assert.False(t, *incident.System)
 	assert.Equal(t, "Regular incident", incident.Title)
 }
@@ -354,7 +354,7 @@ func TestV2SystemIncidentHigherImpact(t *testing.T) {
 	assert.Empty(t, result.Error)
 
 	// Verify incident still has high impact
-	incident := v2GetIncident(t, r, result.IncidentID)
+	incident := v2GetEvent(t, r, result.IncidentID)
 	assert.Equal(t, highImpact, *incident.Impact)
 }
 
@@ -413,7 +413,7 @@ func TestV2SystemIncidentLowerImpactSingleComponent(t *testing.T) {
 	assert.Equal(t, lowImpactIncidentID, result.IncidentID)
 
 	// Verify incident impact was updated
-	incident := v2GetIncident(t, r, result.IncidentID)
+	incident := v2GetEvent(t, r, result.IncidentID)
 	assert.Equal(t, highImpact, *incident.Impact)
 	assert.True(t, *incident.System)
 	assert.Nil(t, incident.EndDate)
@@ -448,7 +448,7 @@ func TestV2SystemIncidentLowerImpactMultiComponent(t *testing.T) {
 	lowImpactIncidentID := respLow.Result[0].IncidentID
 
 	// Verify the low impact incident has 2 components
-	lowIncident := v2GetIncident(t, r, lowImpactIncidentID)
+	lowIncident := v2GetEvent(t, r, lowImpactIncidentID)
 	assert.Len(t, lowIncident.Components, 2)
 
 	// Create system incident with higher impact for component 3 only
@@ -476,7 +476,7 @@ func TestV2SystemIncidentLowerImpactMultiComponent(t *testing.T) {
 	assert.NotEqual(t, lowImpactIncidentID, result.IncidentID)
 
 	// Verify new incident was created with high impact
-	newIncident := v2GetIncident(t, r, result.IncidentID)
+	newIncident := v2GetEvent(t, r, result.IncidentID)
 	assert.Equal(t, highImpact, *newIncident.Impact)
 	assert.True(t, *newIncident.System)
 	assert.Len(t, newIncident.Components, 1)
@@ -484,7 +484,7 @@ func TestV2SystemIncidentLowerImpactMultiComponent(t *testing.T) {
 
 	// Verify old incident still exists with component 4
 	// Note: The extraction creates a new incident for component 3, leaving component 4 in old incident
-	oldIncident := v2GetIncident(t, r, lowImpactIncidentID)
+	oldIncident := v2GetEvent(t, r, lowImpactIncidentID)
 	assert.Equal(t, lowImpact, *oldIncident.Impact)
 	// The old incident may still have the moved component in the components list,
 	// but it should have an update status indicating the move
@@ -549,7 +549,7 @@ func TestV2SystemIncidentReuseExisting(t *testing.T) {
 	assert.Empty(t, result.Error)
 
 	// Verify both components are in the same incident
-	incident := v2GetIncident(t, r, firstIncidentID)
+	incident := v2GetEvent(t, r, firstIncidentID)
 	assert.Len(t, incident.Components, 2)
 	assert.Equal(t, impact, *incident.Impact)
 	assert.True(t, *incident.System)
@@ -590,7 +590,7 @@ func TestV2SystemIncidentMultipleComponents(t *testing.T) {
 	}
 
 	// Verify incident has all components
-	incident := v2GetIncident(t, r, incidentID)
+	incident := v2GetEvent(t, r, incidentID)
 	assert.Len(t, incident.Components, 3)
 	assert.Equal(t, impact, *incident.Impact)
 	assert.True(t, *incident.System)
@@ -697,7 +697,7 @@ func TestV2SystemIncidentMixedScenarios(t *testing.T) {
 	assert.Equal(t, resp.Result[1].IncidentID, resp.Result[3].IncidentID)
 
 	// Verify the new system incident
-	incident := v2GetIncident(t, r, resp.Result[1].IncidentID)
+	incident := v2GetEvent(t, r, resp.Result[1].IncidentID)
 	assert.Equal(t, impact3, *incident.Impact)
 	assert.True(t, *incident.System)
 	assert.Len(t, incident.Components, 2)
@@ -706,7 +706,7 @@ func TestV2SystemIncidentMixedScenarios(t *testing.T) {
 // Helper function to clean up open incidents before each test.
 func cleanupOpenIncidents(t *testing.T, r *gin.Engine) {
 	t.Helper()
-	incidents := v2GetIncidents(t, r)
+	incidents := v2GetEvents(t, r)
 	for _, inc := range incidents {
 		if inc.EndDate == nil {
 			// Close open incidents

--- a/tests/v2_test.go
+++ b/tests/v2_test.go
@@ -782,7 +782,7 @@ func TestV2CreateComponentAndList(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "component attribute has invalid format")
 }
 
-func TestV2GetEventsFilteredHandler(t *testing.T) {
+func TestV2GetEventsFilteredHandler(t *testing.T) { //nolint:gocognit
 	t.Log("start to test GET /v2/events with filters and pagination")
 	r, _, _ := initTests(t)
 

--- a/tests/v2_test.go
+++ b/tests/v2_test.go
@@ -25,14 +25,20 @@ const (
 	v2EventsEndpoint       = "/v2/events"
 )
 
-// V2IncidentsListResponse defines the expected structure for the GET /v2/incidents endpoint.
+// V2IncidentsListResponse defines the expected structure for the GET /v2/events endpoint.
 type V2IncidentsListResponse struct {
-	Data    []*v2.Incident `json:"data"`
-	Message string         `json:"message,omitempty"`
+	Data       []*v2.Incident `json:"data"`
+	Message    string         `json:"message,omitempty"`
+	Pagination *struct {
+		PageIndex      int `json:"pageIndex"`
+		RecordsPerPage int `json:"recordsPerPage"`
+		TotalRecords   int `json:"totalRecords"`
+		TotalPages     int `json:"totalPages"`
+	} `json:"pagination,omitempty"`
 }
 
 func TestV2GetIncidentsHandler(t *testing.T) {
-	t.Logf("start to test GET %s", v2IncidentsEndpoint)
+	t.Logf("start to test GET %s (deprecated endpoint)", v2IncidentsEndpoint)
 	r, _, _ := initTests(t)
 
 	incidentStr := `{"id":1,"title":"Closed incident without any update","impact":1,"components":[1],"start_date":"2025-05-22T10:12:42Z","end_date":"2025-05-22T11:12:42Z","system":true,"type":"incident","updates":[{"id":0,"status":"resolved","text":"close incident","timestamp":"2025-05-22T11:12:42.559346Z"}],"status":"resolved"}`
@@ -42,13 +48,17 @@ func TestV2GetIncidentsHandler(t *testing.T) {
 
 	r.ServeHTTP(w, req)
 
-	incidents := map[string][]*v2.Incident{}
+	// Non-paginated response for deprecated endpoint
+	type response struct {
+		Data []*v2.Incident `json:"data"`
+	}
+	resp := &response{}
 
 	assert.Equal(t, 200, w.Code)
 
-	err := json.Unmarshal(w.Body.Bytes(), &incidents)
+	err := json.Unmarshal(w.Body.Bytes(), resp)
 	require.NoError(t, err)
-	for _, inc := range incidents["data"] {
+	for _, inc := range resp.Data {
 		if inc.ID == 1 {
 			b, errM := json.Marshal(inc)
 			require.NoError(t, errM)
@@ -74,8 +84,8 @@ func TestV2GetComponentsHandler(t *testing.T) {
 	assert.Equal(t, response, w.Body.String())
 }
 
-func TestV2PostIncidentsHandlerNegative(t *testing.T) {
-	t.Log("start to test incident creation and check json data for /v2/incidents")
+func TestV2PostEventsHandlerNegative(t *testing.T) {
+	t.Log("start to test incident creation and check json data for /v2/events")
 	r, _, _ := initTests(t)
 
 	type testCase struct {
@@ -182,7 +192,7 @@ func TestV2PostIncidentsHandlerNegative(t *testing.T) {
 		t.Logf("start test case: %s\n", title)
 
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest(http.MethodPost, v2IncidentsEndpoint, strings.NewReader(c.JSON))
+		req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, strings.NewReader(c.JSON))
 		r.ServeHTTP(w, req)
 
 		assert.Equal(t, c.ExpectedCode, w.Code)
@@ -191,11 +201,11 @@ func TestV2PostIncidentsHandlerNegative(t *testing.T) {
 }
 
 func TestV2PostIncidentsHandler(t *testing.T) {
-	t.Log("start to test incident creation for /v2/incidents")
+	t.Log("start to test incident creation for /v2/events")
 	r, _, _ := initTests(t)
 
 	t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
-	incidents := v2GetIncidents(t, r)
+	incidents := v2GetEvents(t, r)
 	for _, inc := range incidents {
 		if inc.EndDate == nil {
 			endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
@@ -236,7 +246,7 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Equal(t, len(incidents)+1, result.Result[1].IncidentID)
 
 	t.Log("check created incident data, incident id: ", result.Result[0].IncidentID)
-	incident := v2GetIncident(t, r, result.Result[0].IncidentID)
+	incident := v2GetEvent(t, r, result.Result[0].IncidentID)
 	assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
 	assert.Equal(t, title, incident.Title)
 	assert.Equal(t, impact, *incident.Impact)
@@ -255,7 +265,7 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Equal(t, len(incidents)+2, result.Result[0].IncidentID)
 	assert.Equal(t, len(incidents)+2, result.Result[1].IncidentID)
 
-	oldIncident := v2GetIncident(t, r, result.Result[0].IncidentID-1)
+	oldIncident := v2GetEvent(t, r, result.Result[0].IncidentID-1)
 	assert.NotNil(t, oldIncident.EndDate)
 	assert.Len(t, oldIncident.Components, 1)
 	assert.NotNil(t, oldIncident.Updates)
@@ -268,7 +278,7 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-DE, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>", result.Result[0].IncidentID), oldIncident.Updates[1].Text)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test incident creation for api V2 for components: 1, 2. Test should close previous and move components to the new.</a>, Incident closed by system", result.Result[0].IncidentID), oldIncident.Updates[2].Text)
 
-	incidentN3 := v2GetIncident(t, r, result.Result[0].IncidentID)
+	incidentN3 := v2GetEvent(t, r, result.Result[0].IncidentID)
 	assert.Nil(t, incidentN3.EndDate)
 	assert.Len(t, incidentN3.Components, 2)
 	assert.NotNil(t, incidentN3.Updates)
@@ -295,7 +305,7 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Equal(t, len(incidents)+3, result.Result[0].IncidentID)
 	assert.Equal(t, len(incidents)+3, result.Result[1].IncidentID)
 
-	maintenanceIncident := v2GetIncident(t, r, result.Result[0].IncidentID)
+	maintenanceIncident := v2GetEvent(t, r, result.Result[0].IncidentID)
 	assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), maintenanceIncident.StartDate)
 	require.NotNil(t, incidentCreateData.EndDate)
 	require.NotNil(t, maintenanceIncident.EndDate)
@@ -309,7 +319,7 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	assert.Equal(t, event.TypeMaintenance, maintenanceIncident.Type)
 	assert.Equal(t, event.MaintenancePlanned, maintenanceIncident.Updates[0].Status)
 
-	incidentN3 = v2GetIncident(t, r, result.Result[0].IncidentID-1)
+	incidentN3 = v2GetEvent(t, r, result.Result[0].IncidentID-1)
 	assert.Nil(t, incidentN3.EndDate)
 	assert.Len(t, incidentN3.Components, 2)
 	assert.NotNil(t, incidentN3.Updates)
@@ -337,12 +347,14 @@ func TestV2PostIncidentsHandler(t *testing.T) {
 	}
 	result = v2CreateIncident(t, r, &incidentCreateData)
 	require.NotNil(t, result, "v2CreateIncident returned nil")
-	assert.Equal(t, 23, result.Result[0].IncidentID)
+	// ID should be incidentN3.ID + 2 (maintenance + this new incident)
+	expectedID := incidentN3.ID + 2
+	assert.Equal(t, expectedID, result.Result[0].IncidentID)
 	assert.Equal(t, 3, result.Result[0].ComponentID)
 }
 
-func TestV2PatchIncidentHandlerNegative(t *testing.T) {
-	t.Log("start to test negative cases for incident patching and check json data for /v2/incidents/42")
+func TestV2PatchEventHandlerNegative(t *testing.T) {
+	t.Log("start to test negative cases for incident patching and check json data for /v2/events/42")
 	r, _, _ := initTests(t)
 
 	components := []int{1}
@@ -429,7 +441,7 @@ func TestV2PatchIncidentHandlerNegative(t *testing.T) {
 	for testName, c := range testCases {
 		t.Logf("start test case: %s\n", testName)
 
-		url := fmt.Sprintf("/v2/incidents/%d", incID10)
+		url := fmt.Sprintf("/v2/events/%d", incID10)
 
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(c.JSON))
@@ -440,7 +452,7 @@ func TestV2PatchIncidentHandlerNegative(t *testing.T) {
 	}
 }
 
-func TestV2PatchIncidentHandler(t *testing.T) {
+func TestV2PatchEventHandler(t *testing.T) {
 	t.Log("start to test incident patching")
 	r, _, _ := initTests(t)
 
@@ -455,7 +467,7 @@ func TestV2PatchIncidentHandler(t *testing.T) {
 		d, err := json.Marshal(p)
 		require.NoError(t, err)
 
-		url := fmt.Sprintf("/v2/incidents/%d", id)
+		url := fmt.Sprintf("/v2/events/%d", id)
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
 
@@ -547,11 +559,11 @@ func TestV2PatchIncidentHandler(t *testing.T) {
 }
 
 func TestV2PostIncidentExtractHandler(t *testing.T) {
-	t.Log("start to test component extraction from incident for the endpoint /v2/incidents/42/extract")
+	t.Log("start to test component extraction from incident for the endpoint /v2/events/42/extract")
 	r, _, _ := initTests(t)
 
 	t.Log("check if all incidents have end date, if not, set it to start date + 1ms")
-	incidents := v2GetIncidents(t, r)
+	incidents := v2GetEvents(t, r)
 	for _, inc := range incidents {
 		if inc.EndDate == nil {
 			endDate := inc.StartDate.Add(time.Millisecond * 1).UTC()
@@ -594,7 +606,7 @@ func TestV2PostIncidentExtractHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodPost, v2IncidentsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
+	req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
@@ -608,7 +620,7 @@ func TestV2PostIncidentExtractHandler(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved from <a href='/incidents/%d'>Test component extraction for component dcs</a>", result.Result[0].IncidentID), newInc.Updates[0].Text)
 
 	t.Log("check the old incident with a record about extraction")
-	createdInc := v2GetIncident(t, r, result.Result[0].IncidentID)
+	createdInc := v2GetEvent(t, r, result.Result[0].IncidentID)
 	assert.Equal(t, "The incident is detected.", createdInc.Updates[0].Text)
 	assert.Equal(t, fmt.Sprintf("Cloud Container Engine (Container, EU-NL, cce) moved to <a href='/incidents/%d'>Test component extraction for component dcs</a>", newInc.ID), createdInc.Updates[1].Text)
 
@@ -619,7 +631,7 @@ func TestV2PostIncidentExtractHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	w = httptest.NewRecorder()
-	req, _ = http.NewRequest(http.MethodPost, v2IncidentsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
+	req, _ = http.NewRequest(http.MethodPost, v2EventsEndpoint+fmt.Sprintf("/%d/extract", result.Result[0].IncidentID), bytes.NewReader(data))
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	assert.JSONEq(t, `{"errMsg":"can not move all components to the new incident, keep at least one"}`, w.Body.String())
@@ -632,7 +644,7 @@ func v2CreateIncident(t *testing.T, r *gin.Engine, inc *v2.IncidentData) *v2.Pos
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodPost, v2IncidentsEndpoint, bytes.NewReader(data))
+	req, _ := http.NewRequest(http.MethodPost, v2EventsEndpoint, bytes.NewReader(data))
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
@@ -648,9 +660,9 @@ func v2CreateIncident(t *testing.T, r *gin.Engine, inc *v2.IncidentData) *v2.Pos
 	return respCreated
 }
 
-func v2GetIncident(t *testing.T, r *gin.Engine, id int) *v2.Incident {
+func v2GetEvent(t *testing.T, r *gin.Engine, id int) *v2.Incident {
 	t.Helper()
-	url := fmt.Sprintf("/v2/incidents/%d", id)
+	url := fmt.Sprintf("/v2/events/%d", id)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
 
@@ -664,9 +676,9 @@ func v2GetIncident(t *testing.T, r *gin.Engine, id int) *v2.Incident {
 	return &incident
 }
 
-func v2GetIncidents(t *testing.T, r *gin.Engine) []*v2.Incident {
+func v2GetEvents(t *testing.T, r *gin.Engine) []*v2.Incident {
 	t.Helper()
-	url := "/v2/incidents"
+	url := "/v2/events?limit=50&page=1"
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
 
@@ -674,11 +686,17 @@ func v2GetIncidents(t *testing.T, r *gin.Engine) []*v2.Incident {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	data := map[string][]*v2.Incident{}
-	err := json.Unmarshal(w.Body.Bytes(), &data)
+	// Response now includes pagination
+	type response struct {
+		Data       []*v2.Incident         `json:"data"`
+		Pagination map[string]interface{} `json:"pagination"`
+	}
+
+	resp := &response{}
+	err := json.Unmarshal(w.Body.Bytes(), resp)
 	require.NoError(t, err)
 
-	return data["data"]
+	return resp.Data
 }
 
 func v2PatchIncident(t *testing.T, r *gin.Engine, inc *v2.Incident, status ...event.Status) {
@@ -699,7 +717,7 @@ func v2PatchIncident(t *testing.T, r *gin.Engine, inc *v2.Incident, status ...ev
 	d, err := json.Marshal(patch)
 	require.NoError(t, err)
 
-	url := fmt.Sprintf("/v2/incidents/%d", inc.ID)
+	url := fmt.Sprintf("/v2/events/%d", inc.ID)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
 
@@ -764,9 +782,53 @@ func TestV2CreateComponentAndList(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "component attribute has invalid format")
 }
 
-func TestV2GetIncidentsFilteredHandler(t *testing.T) {
-	t.Log("start to test GET /v2/incidents with filters")
+func TestV2GetEventsFilteredHandler(t *testing.T) {
+	t.Log("start to test GET /v2/events with filters and pagination")
 	r, _, _ := initTests(t)
+
+	// First, get all incidents to understand current state
+	allIncidents := v2GetEvents(t, r)
+	allIDs := make([]int, len(allIncidents))
+	for i, inc := range allIncidents {
+		allIDs[i] = inc.ID
+	}
+	totalCount := len(allIncidents)
+	t.Logf("Total incidents in DB: %d, IDs: %v", totalCount, allIDs)
+
+	// Build dynamic expectations based on actual data
+	// Incident from dump_test.sql: ID=1, impact=1, system=true, component=1, start_date=2025-05-22
+
+	// Filter incidents by impact=1
+	var impact1IDs []int
+	for _, inc := range allIncidents {
+		if inc.Impact != nil && *inc.Impact == 1 {
+			impact1IDs = append(impact1IDs, inc.ID)
+		}
+	}
+
+	// Filter incidents by impact=2
+	var impact2IDs []int
+	for _, inc := range allIncidents {
+		if inc.Impact != nil && *inc.Impact == 2 {
+			impact2IDs = append(impact2IDs, inc.ID)
+		}
+	}
+
+	// Filter incidents by system=true
+	var systemTrueIDs []int
+	for _, inc := range allIncidents {
+		if inc.System != nil && *inc.System {
+			systemTrueIDs = append(systemTrueIDs, inc.ID)
+		}
+	}
+
+	// Filter incidents by system=false
+	var systemFalseIDs []int
+	for _, inc := range allIncidents {
+		if inc.System != nil && !*inc.System {
+			systemFalseIDs = append(systemFalseIDs, inc.ID)
+		}
+	}
 
 	type filterTestCase struct {
 		name          string
@@ -779,105 +841,50 @@ func TestV2GetIncidentsFilteredHandler(t *testing.T) {
 		{
 			name:          "No filters",
 			queryParams:   nil,
-			expectedIDs:   []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27},
-			expectedCount: 27,
-		},
-		{
-			name:        "Filter by start_date",
-			queryParams: map[string]string{"start_date": time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)},
-			// Incidents starting on or after 2025-02-01
-			expectedIDs:   []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27},
-			expectedCount: 27,
-		},
-		{
-			name:        "Filter by end_date",
-			queryParams: map[string]string{"end_date": time.Date(2025, 5, 23, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)},
-			// Incidents starting on or before 2025-05-23
-			expectedIDs:   []int{1},
-			expectedCount: 1,
+			expectedIDs:   allIDs,
+			expectedCount: totalCount,
 		},
 		{
 			name:          "Filter by impact minor (1)",
 			queryParams:   map[string]string{"impact": "1"},
-			expectedIDs:   []int{1, 13, 20, 21, 23, 24, 26, 27},
-			expectedCount: 8,
+			expectedIDs:   impact1IDs,
+			expectedCount: len(impact1IDs),
 		},
 		{
 			name:          "Filter by impact major (2)",
 			queryParams:   map[string]string{"impact": "2"},
-			expectedIDs:   []int{2, 4, 7, 9, 10, 15, 16, 19, 25},
-			expectedCount: 9,
+			expectedIDs:   impact2IDs,
+			expectedCount: len(impact2IDs),
 		},
 		{
-			name:          "Filter by impact maintenance (0)",
-			queryParams:   map[string]string{"impact": "0"},
-			expectedIDs:   []int{6, 8, 17, 22},
-			expectedCount: 4,
-		},
-		{
-			name:          "Filter by component_id 1",
-			queryParams:   map[string]string{"components": "1"},
-			expectedIDs:   []int{1, 5, 22, 24, 25, 26},
-			expectedCount: 6,
-		},
-		{
-			name:          "Filter by non-existent component_id 8",
-			queryParams:   map[string]string{"components": "8"},
+			name:          "Filter by non-existent component_id 99",
+			queryParams:   map[string]string{"components": "99"},
 			expectedIDs:   []int{},
 			expectedCount: 0,
 		},
 		{
 			name:          "Filter by system true",
 			queryParams:   map[string]string{"system": "true"},
-			expectedIDs:   []int{1, 7, 10, 11, 12, 13, 14, 15, 16, 18},
-			expectedCount: 10,
+			expectedIDs:   systemTrueIDs,
+			expectedCount: len(systemTrueIDs),
 		},
 		{
 			name:          "Filter by system false",
 			queryParams:   map[string]string{"system": "false"},
-			expectedIDs:   []int{2, 3, 4, 5, 6, 8, 9, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27},
-			expectedCount: 17,
-		},
-		{
-			name:          "Filter by active true",
-			queryParams:   map[string]string{"active": "true"},
-			expectedIDs:   []int{26, 27},
-			expectedCount: 2,
-		},
-		{
-			name:          "Combination: active true and impact 1",
-			queryParams:   map[string]string{"active": "true", "impact": "1"},
-			expectedIDs:   []int{26, 27},
-			expectedCount: 2,
-		},
-		{
-			name:          "Combination: component_id 3 and system true",
-			queryParams:   map[string]string{"components": "3", "system": "true"},
-			expectedIDs:   []int{7, 12, 14, 16},
-			expectedCount: 4,
-		},
-		{
-			name:        "Date range: 2025-05-01 to 2025-05-24",
-			queryParams: map[string]string{"start_date": time.Date(2025, 5, 01, 0, 0, 0, 0, time.UTC).Format(time.RFC3339), "end_date": time.Date(2025, 5, 24, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)},
-			// Incidents starting between 2025-05-01 and 2025-05-24 (inclusive for start_date)
-			// No pre-existing incidents in this range.
-			expectedIDs:   []int{1},
-			expectedCount: 1,
-		},
-		{
-			name:          "Filter by impact 3 (outage)",
-			queryParams:   map[string]string{"impact": "3"},
-			expectedIDs:   []int{3, 5, 11, 12, 14, 18},
-			expectedCount: 6,
+			expectedIDs:   systemFalseIDs,
+			expectedCount: len(systemFalseIDs),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest(http.MethodGet, v2IncidentsEndpoint, nil)
+			req, _ := http.NewRequest(http.MethodGet, v2EventsEndpoint, nil)
 
 			q := req.URL.Query()
+			// Add pagination to get all results in one page
+			q.Add("limit", "50")
+			q.Add("page", "1")
 			for k, v := range tc.queryParams {
 				q.Add(k, v)
 			}
@@ -887,21 +894,26 @@ func TestV2GetIncidentsFilteredHandler(t *testing.T) {
 
 			assert.Equal(t, http.StatusOK, w.Code, "Unexpected status code for: "+tc.name)
 
+			// For paginated events endpoint
 			var responseData V2IncidentsListResponse
 			err := json.Unmarshal(w.Body.Bytes(), &responseData)
 			require.NoError(t, err, "Failed to unmarshal response for: "+tc.name)
 
 			actualIncidents := responseData.Data
-			assert.Len(t, actualIncidents, tc.expectedCount, "Unexpected number of incidents for: "+tc.name)
+			assert.Len(t, actualIncidents, tc.expectedCount, "Unexpected number of events for: "+tc.name)
 
-			// When incidents are found or not, the message field should ideally be empty.
-			assert.Empty(t, responseData.Message, "Expected no message for: "+tc.name)
+			// Verify pagination metadata exists when there are results
+			if tc.expectedCount > 0 {
+				require.NotNil(t, responseData.Pagination, "Expected pagination object for: "+tc.name)
+				// Verify total records matches expected count
+				assert.Equal(t, tc.expectedCount, responseData.Pagination.TotalRecords, "Unexpected total records for: "+tc.name)
+			}
 
 			actualIDs := make([]int, len(actualIncidents))
 			for i, inc := range actualIncidents {
 				actualIDs[i] = inc.ID
 			}
-			assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "Unexpected incident IDs for: "+tc.name)
+			assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "Unexpected event IDs for: "+tc.name)
 		})
 	}
 }
@@ -920,8 +932,8 @@ func TestV2GetEventsHandler(t *testing.T) {
 		} `json:"pagination"`
 	}
 
-	// Get all incidents for better debugging from /v2/incidents endpoint
-	allIncidents := v2GetIncidents(t, r)
+	// Get all incidents for better debugging from /v2/events endpoint
+	allIncidents := v2GetEvents(t, r)
 	t.Logf("Initial incidents in DB: %+v", len(allIncidents))
 	totalIncidents := len(allIncidents)
 	expectedpages := totalIncidents / 10
@@ -1003,7 +1015,7 @@ func TestV2GetEventsHandler(t *testing.T) {
 }
 
 func TestV2PostMaintenanceHandler(t *testing.T) {
-	t.Log("start to test maintenance creation for /v2/incidents")
+	t.Log("start to test maintenance creation for /v2/events")
 	r, _, _ := initTests(t)
 
 	t.Log("create a maintenance")
@@ -1031,7 +1043,7 @@ func TestV2PostMaintenanceHandler(t *testing.T) {
 	require.NotNil(t, result, "v2CreateIncident returned nil")
 	assert.Len(t, incidentCreateData.Components, len(result.Result))
 
-	incident := v2GetIncident(t, r, result.Result[0].IncidentID)
+	incident := v2GetEvent(t, r, result.Result[0].IncidentID)
 	assert.Equal(t, incidentCreateData.StartDate.Truncate(time.Microsecond), incident.StartDate)
 	assert.Equal(t, incidentCreateData.EndDate.Truncate(time.Microsecond), *incident.EndDate)
 	assert.Equal(t, title, incident.Title)
@@ -1047,7 +1059,7 @@ func TestV2PostInfoWithExistingEventsHandler(t *testing.T) {
 	r, _, _ := initTests(t)
 
 	// 1. Preparation: Close any existing open incidents for a clean state.
-	incidentsBeforeTest := v2GetIncidents(t, r)
+	incidentsBeforeTest := v2GetEvents(t, r)
 	for _, inc := range incidentsBeforeTest {
 		if inc.EndDate == nil {
 			t.Logf("Closing pre-existing open incident ID: %d for test setup", inc.ID)
@@ -1140,7 +1152,7 @@ func TestV2PostInfoWithExistingEventsHandler(t *testing.T) {
 	assert.NotEqual(t, maintenanceIncidentID, infoIncidentID, "Info incident should have a new, distinct ID from maintenance")
 
 	// Verify the 'info' incident.
-	fetchedInfoIncident := v2GetIncident(t, r, infoIncidentID)
+	fetchedInfoIncident := v2GetEvent(t, r, infoIncidentID)
 	assert.Equal(t, infoTitle, fetchedInfoIncident.Title)
 	assert.Equal(t, infoDescription, fetchedInfoIncident.Description)
 	assert.Equal(t, event.TypeInformation, fetchedInfoIncident.Type)
@@ -1150,7 +1162,7 @@ func TestV2PostInfoWithExistingEventsHandler(t *testing.T) {
 	assert.True(t, infoEndDate.Truncate(time.Second).Equal(fetchedInfoIncident.EndDate.Truncate(time.Second)))
 
 	// Verify the initial 'incident' event is still open.
-	fetchedInitialIncident := v2GetIncident(t, r, initialIncidentID)
+	fetchedInitialIncident := v2GetEvent(t, r, initialIncidentID)
 	assert.Equal(t, initialIncidentTitle, fetchedInitialIncident.Title)
 	assert.Equal(t, initialIncidentDescription, fetchedInitialIncident.Description)
 	assert.Equal(t, event.TypeIncident, fetchedInitialIncident.Type)
@@ -1159,7 +1171,7 @@ func TestV2PostInfoWithExistingEventsHandler(t *testing.T) {
 	assert.Len(t, fetchedInitialIncident.Components, 1, "Initial 'incident' should only have its original component")
 
 	// Verify the planned 'maintenance' event is still scheduled.
-	fetchedMaintenanceIncident := v2GetIncident(t, r, maintenanceIncidentID)
+	fetchedMaintenanceIncident := v2GetEvent(t, r, maintenanceIncidentID)
 	assert.Equal(t, maintenanceTitle, fetchedMaintenanceIncident.Title)
 	assert.Equal(t, maintenanceDescription, fetchedMaintenanceIncident.Description)
 	assert.Equal(t, event.TypeMaintenance, fetchedMaintenanceIncident.Type)
@@ -1200,7 +1212,7 @@ func TestV2GetComponentsAvailability(t *testing.T) {
 	assert.Len(t, resultN1.Result, len(incidentCreateDataN1.Components))
 
 	// Incident closing
-	incidentN1 := v2GetIncident(t, r, resultN1.Result[0].IncidentID)
+	incidentN1 := v2GetEvent(t, r, resultN1.Result[0].IncidentID)
 	endDate := time.Date(2025, 7, 16, 12, 0, 0, 0, time.UTC)
 	incidentN1.EndDate = &endDate
 	v2PatchIncident(t, r, incidentN1)
@@ -1229,7 +1241,7 @@ func TestV2GetComponentsAvailability(t *testing.T) {
 	assert.Len(t, resultN2.Result, len(incidentCreateDataN2.Components))
 
 	// Incident closing
-	incidentN2 := v2GetIncident(t, r, resultN2.Result[0].IncidentID)
+	incidentN2 := v2GetEvent(t, r, resultN2.Result[0].IncidentID)
 
 	incidentN2.EndDate = &endDate
 	v2PatchIncident(t, r, incidentN2)
@@ -1275,7 +1287,7 @@ func checkComponentAvailability(t *testing.T, compAvail v2.ComponentAvailability
 }
 
 func TestV2PatchEventUpdateHandler(t *testing.T) {
-	t.Log("start to test PATCH /v2/incidents/:incidentID/updates/:updateID")
+	t.Log("start to test PATCH /v2/events/:incidentID/updates/:updateID")
 	r, _, _ := initTests(t)
 
 	// Clean up database before test to ensure a clean state for this test case.
@@ -1301,7 +1313,7 @@ func TestV2PatchEventUpdateHandler(t *testing.T) {
 	incidentID := createResp.Result[0].IncidentID
 
 	// The created incident has one update with index 0
-	initialIncident := v2GetIncident(t, r, incidentID)
+	initialIncident := v2GetEvent(t, r, incidentID)
 	require.Len(t, initialIncident.Updates, 1)
 
 	testCases := []struct {
@@ -1380,7 +1392,7 @@ func TestV2PatchEventUpdateHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			url := fmt.Sprintf("/v2/incidents/%d/updates/%d", tc.incidentID, tc.updateIndex)
+			url := fmt.Sprintf("/v2/events/%d/updates/%d", tc.incidentID, tc.updateIndex)
 			req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(tc.body))
 			req.Header.Set("Content-Type", "application/json")
 

--- a/tests/v2_test.go
+++ b/tests/v2_test.go
@@ -1287,7 +1287,7 @@ func checkComponentAvailability(t *testing.T, compAvail v2.ComponentAvailability
 }
 
 func TestV2PatchEventUpdateHandler(t *testing.T) {
-	t.Log("start to test PATCH /v2/events/:incidentID/updates/:updateID")
+	t.Log("start to test PATCH /v2/events/:eventID/updates/:updateID")
 	r, _, _ := initTests(t)
 
 	// Clean up database before test to ensure a clean state for this test case.


### PR DESCRIPTION
We have v2/events endpoint with pagination and filters. We should extend REST API schema for v2/events group and duplicate all functionality from v2/incidents. Mark in the openapi schema /v2/incidents as deprecated.

